### PR TITLE
Fix redux example so that users without devtools installed can view it

### DIFF
--- a/examples/redux-fetch/callbag/package.json
+++ b/examples/redux-fetch/callbag/package.json
@@ -9,6 +9,7 @@
         "react-scripts": "1.0.10",
         "react-state-hoc": "~2.0.0",
         "redux": "~4.0.0",
+        "redux-devtools-extension": "~2.13.5",
         "refract-callbag": "~1.0.0",
         "refract-redux-callbag": "~1.0.0"
     },

--- a/examples/redux-fetch/callbag/src/setupStore.js
+++ b/examples/redux-fetch/callbag/src/setupStore.js
@@ -1,14 +1,9 @@
-import { compose, createStore } from 'redux'
+import { createStore } from 'redux'
 import { refractEnhancer } from 'refract-redux-callbag'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 import reducers from './store'
 
-let composeEnhancers = compose
-
-if (process.env.NODE_ENV !== 'production') {
-    composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-}
-
-const store = createStore(reducers, {}, composeEnhancers(refractEnhancer()))
+const store = createStore(reducers, {}, composeWithDevTools(refractEnhancer()))
 
 export default store

--- a/examples/redux-fetch/most/package.json
+++ b/examples/redux-fetch/most/package.json
@@ -8,6 +8,7 @@
         "react-scripts": "1.0.10",
         "react-state-hoc": "~2.0.0",
         "redux": "4.0.0",
+        "redux-devtools-extension": "~2.13.5",
         "refract-most": "~1.0.0",
         "refract-redux-most": "~1.0.0"
     },

--- a/examples/redux-fetch/most/src/setupStore.js
+++ b/examples/redux-fetch/most/src/setupStore.js
@@ -1,14 +1,9 @@
-import { compose, createStore } from 'redux'
+import { createStore } from 'redux'
 import { refractEnhancer } from 'refract-redux-most'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 import reducers from './store'
 
-let composeEnhancers = compose
-
-if (process.env.NODE_ENV !== 'production') {
-    composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-}
-
-const store = createStore(reducers, {}, composeEnhancers(refractEnhancer()))
+const store = createStore(reducers, {}, composeWithDevTools(refractEnhancer()))
 
 export default store

--- a/examples/redux-fetch/rxjs/package.json
+++ b/examples/redux-fetch/rxjs/package.json
@@ -7,6 +7,7 @@
         "react-scripts": "1.0.10",
         "react-state-hoc": "~2.0.0",
         "redux": "~4.0.0",
+        "redux-devtools-extension": "~2.13.5",
         "refract-redux-rxjs": "~1.0.0",
         "refract-rxjs": "~1.0.0",
         "rxjs": "~6.2.1",

--- a/examples/redux-fetch/rxjs/src/setupStore.js
+++ b/examples/redux-fetch/rxjs/src/setupStore.js
@@ -1,14 +1,9 @@
-import { compose, createStore } from 'redux'
+import { createStore } from 'redux'
 import { refractEnhancer } from 'refract-redux-rxjs'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 import reducers from './store'
 
-let composeEnhancers = compose
-
-if (process.env.NODE_ENV !== 'production') {
-    composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-}
-
-const store = createStore(reducers, {}, composeEnhancers(refractEnhancer()))
+const store = createStore(reducers, {}, composeWithDevTools(refractEnhancer()))
 
 export default store

--- a/examples/redux-fetch/xstream/package.json
+++ b/examples/redux-fetch/xstream/package.json
@@ -7,6 +7,7 @@
         "react-scripts": "1.0.10",
         "react-state-hoc": "~2.0.0",
         "redux": "~4.0.0",
+        "redux-devtools-extension": "~2.13.5",
         "refract-redux-xstream": "~1.0.0",
         "refract-xstream": "~1.0.0",
         "xstream": "~11.4.0"

--- a/examples/redux-fetch/xstream/src/setupStore.js
+++ b/examples/redux-fetch/xstream/src/setupStore.js
@@ -1,14 +1,9 @@
-import { compose, createStore } from 'redux'
+import { createStore } from 'redux'
 import { refractEnhancer } from 'refract-redux-xstream'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 import reducers from './store'
 
-let composeEnhancers = compose
-
-if (process.env.NODE_ENV !== 'production') {
-    composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-}
-
-const store = createStore(reducers, {}, composeEnhancers(refractEnhancer()))
+const store = createStore(reducers, {}, composeWithDevTools(refractEnhancer()))
 
 export default store


### PR DESCRIPTION
The examples assumed the user had the devtools installed, and completely broke if they were not available. Best to leave that detection to the npm module!