### PR TITLE
Update examples/counter

### DIFF
--- a/examples/counter/callbag/package.json
+++ b/examples/counter/callbag/package.json
@@ -4,10 +4,9 @@
         "callbag-basics": "~3.0.0",
         "callbag-combine": "~1.1.0",
         "callbag-interval": "~1.0.0",
-        "react": "16.1.1",
-        "react-dom": "16.1.1",
-        "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
+        "react": "~16.4.2",
+        "react-dom": "~16.4.2",
+        "react-scripts": "~1.1.5",
         "refract-callbag": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/counter/callbag/public/style.css
+++ b/examples/counter/callbag/public/style.css
@@ -1,4 +1,6 @@
-html, body, button {
+html,
+body,
+button {
     font-family: Ubuntu, Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 10px;
@@ -14,7 +16,7 @@ p:not(:first-child) {
 }
 
 button {
-    background: #50B979;
+    background: #50b979;
     border: none;
     border-radius: 4px;
     color: #fff;
@@ -22,11 +24,12 @@ button {
     font-size: 1rem;
     line-height: 2;
     outline: none;
-    padding: 0 .5em;
+    padding: 0 0.5em;
 }
 
-button:hover {
-    background: #225BC1;
+button:hover,
+button.active {
+    background: #225bc1;
 }
 
 button + button {

--- a/examples/counter/callbag/src/Layout.js
+++ b/examples/counter/callbag/src/Layout.js
@@ -5,9 +5,24 @@ const Layout = ({ count, direction, setDirection }) => (
         <p>Current count: {count}</p>
         <p>Current direction: {direction}</p>
         <p>
-            <button onClick={() => setDirection('INCREASE')}>Increase</button>
-            <button onClick={() => setDirection('NONE')}>Pause</button>
-            <button onClick={() => setDirection('DECREASE')}>Decrease</button>
+            <button
+                className={direction === 'INCREASE' && 'active'}
+                onClick={() => setDirection('INCREASE')}
+            >
+                Increase
+            </button>
+            <button
+                className={direction === 'NONE' && 'active'}
+                onClick={() => setDirection('NONE')}
+            >
+                Pause
+            </button>
+            <button
+                className={direction === 'DECREASE' && 'active'}
+                onClick={() => setDirection('DECREASE')}
+            >
+                Decrease
+            </button>
         </p>
     </div>
 )

--- a/examples/counter/callbag/src/StateContainer.js
+++ b/examples/counter/callbag/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { count: 0, direction: 'NONE' }
+    setDirection = direction => this.setState({ direction })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { count, direction } = this.state
+        const { setDirection, setState } = this
+
+        return this.props.children({
+            count,
+            direction,
+            setDirection,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/counter/callbag/src/index.js
+++ b/examples/counter/callbag/src/index.js
@@ -1,40 +1,40 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-callbag'
 import interval from 'callbag-interval'
 import combine from 'callbag-combine'
 import { map, pipe } from 'callbag-basics'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
-
-const handler = props => effect => {
-    if (effect.type === 'INCREASE') {
-        props.setState(({ count }) => ({ count: count + 1 }))
-    }
-
-    if (effect.type === 'DECREASE') {
-        props.setState(({ count }) => ({ count: count - 1 }))
-    }
-}
 
 const aperture = props => component => {
     const direction$ = component.observe('direction')
-
     const tick$ = interval(1000)
 
-    return pipe(
-        combine(tick$, direction$),
-        map(([, type]) => ({ type }))
-    )
+    const combined$ = combine(direction$, tick$)
+
+    return pipe(combined$, map(([type]) => ({ type })))
 }
 
-const initialState = { count: 0, direction: 'NONE' }
+const handler = props => effect => {
+    switch (effect.type) {
+        case 'DECREASE':
+            return props.setState(({ count }) => ({ count: count - 1 }))
 
-const mapSetStateToProps = { setDirection: direction => ({ direction }) }
+        case 'INCREASE':
+            return props.setState(({ count }) => ({ count: count + 1 }))
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+        default:
+            return
+    }
+}
+
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/counter/most/package.json
+++ b/examples/counter/most/package.json
@@ -2,10 +2,9 @@
     "name": "refract-example-most-counter",
     "dependencies": {
         "most": "~1.7.3",
-        "react": "16.1.1",
-        "react-dom": "16.1.1",
-        "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
+        "react": "~16.4.2",
+        "react-dom": "~16.4.2",
+        "react-scripts": "~1.1.5",
         "refract-most": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/counter/most/public/style.css
+++ b/examples/counter/most/public/style.css
@@ -1,4 +1,6 @@
-html, body, button {
+html,
+body,
+button {
     font-family: Ubuntu, Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 10px;
@@ -14,7 +16,7 @@ p:not(:first-child) {
 }
 
 button {
-    background: #50B979;
+    background: #50b979;
     border: none;
     border-radius: 4px;
     color: #fff;
@@ -22,11 +24,12 @@ button {
     font-size: 1rem;
     line-height: 2;
     outline: none;
-    padding: 0 .5em;
+    padding: 0 0.5em;
 }
 
-button:hover {
-    background: #225BC1;
+button:hover,
+button.active {
+    background: #225bc1;
 }
 
 button + button {

--- a/examples/counter/most/src/Layout.js
+++ b/examples/counter/most/src/Layout.js
@@ -5,9 +5,24 @@ const Layout = ({ count, direction, setDirection }) => (
         <p>Current count: {count}</p>
         <p>Current direction: {direction}</p>
         <p>
-            <button onClick={() => setDirection('INCREASE')}>Increase</button>
-            <button onClick={() => setDirection('NONE')}>Pause</button>
-            <button onClick={() => setDirection('DECREASE')}>Decrease</button>
+            <button
+                className={direction === 'INCREASE' && 'active'}
+                onClick={() => setDirection('INCREASE')}
+            >
+                Increase
+            </button>
+            <button
+                className={direction === 'NONE' && 'active'}
+                onClick={() => setDirection('NONE')}
+            >
+                Pause
+            </button>
+            <button
+                className={direction === 'DECREASE' && 'active'}
+                onClick={() => setDirection('DECREASE')}
+            >
+                Decrease
+            </button>
         </p>
     </div>
 )

--- a/examples/counter/most/src/StateContainer.js
+++ b/examples/counter/most/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { count: 0, direction: 'NONE' }
+    setDirection = direction => this.setState({ direction })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { count, direction } = this.state
+        const { setDirection, setState } = this
+
+        return this.props.children({
+            count,
+            direction,
+            setDirection,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/counter/most/src/index.js
+++ b/examples/counter/most/src/index.js
@@ -1,35 +1,36 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-most'
 import { combine, periodic } from 'most'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
-
-const handler = props => effect => {
-    if (effect.type === 'INCREASE') {
-        props.setState(({ count }) => ({ count: count + 1 }))
-    }
-
-    if (effect.type === 'DECREASE') {
-        props.setState(({ count }) => ({ count: count - 1 }))
-    }
-}
 
 const aperture = props => component => {
     const direction$ = component.observe('direction')
-
     const tick$ = periodic(1000)
 
     return combine(type => ({ type }), direction$, tick$)
 }
 
-const initialState = { count: 0, direction: 'NONE' }
+const handler = props => effect => {
+    switch (effect.type) {
+        case 'DECREASE':
+            return props.setState(({ count }) => ({ count: count - 1 }))
 
-const mapSetStateToProps = { setDirection: direction => ({ direction }) }
+        case 'INCREASE':
+            return props.setState(({ count }) => ({ count: count + 1 }))
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+        default:
+            return
+    }
+}
+
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/counter/rxjs/package.json
+++ b/examples/counter/rxjs/package.json
@@ -1,10 +1,9 @@
 {
     "name": "refract-example-rxjs-counter",
     "dependencies": {
-        "react": "16.1.1",
-        "react-dom": "16.1.1",
-        "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
+        "react": "~16.4.2",
+        "react-dom": "~16.4.2",
+        "react-scripts": "~1.1.5",
         "refract-rxjs": "~1.0.0",
         "rxjs": "~6.2.2",
         "rxjs-compat": "~6.2.2"

--- a/examples/counter/rxjs/public/style.css
+++ b/examples/counter/rxjs/public/style.css
@@ -1,4 +1,6 @@
-html, body, button {
+html,
+body,
+button {
     font-family: Ubuntu, Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 10px;
@@ -14,7 +16,7 @@ p:not(:first-child) {
 }
 
 button {
-    background: #50B979;
+    background: #50b979;
     border: none;
     border-radius: 4px;
     color: #fff;
@@ -22,11 +24,12 @@ button {
     font-size: 1rem;
     line-height: 2;
     outline: none;
-    padding: 0 .5em;
+    padding: 0 0.5em;
 }
 
-button:hover {
-    background: #225BC1;
+button:hover,
+button.active {
+    background: #225bc1;
 }
 
 button + button {

--- a/examples/counter/rxjs/src/Layout.js
+++ b/examples/counter/rxjs/src/Layout.js
@@ -5,9 +5,24 @@ const Layout = ({ count, direction, setDirection }) => (
         <p>Current count: {count}</p>
         <p>Current direction: {direction}</p>
         <p>
-            <button onClick={() => setDirection('INCREASE')}>Increase</button>
-            <button onClick={() => setDirection('NONE')}>Pause</button>
-            <button onClick={() => setDirection('DECREASE')}>Decrease</button>
+            <button
+                className={direction === 'INCREASE' && 'active'}
+                onClick={() => setDirection('INCREASE')}
+            >
+                Increase
+            </button>
+            <button
+                className={direction === 'NONE' && 'active'}
+                onClick={() => setDirection('NONE')}
+            >
+                Pause
+            </button>
+            <button
+                className={direction === 'DECREASE' && 'active'}
+                onClick={() => setDirection('DECREASE')}
+            >
+                Decrease
+            </button>
         </p>
     </div>
 )

--- a/examples/counter/rxjs/src/StateContainer.js
+++ b/examples/counter/rxjs/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { count: 0, direction: 'NONE' }
+    setDirection = direction => this.setState({ direction })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { count, direction } = this.state
+        const { setDirection, setState } = this
+
+        return this.props.children({
+            count,
+            direction,
+            setDirection,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/counter/rxjs/src/index.js
+++ b/examples/counter/rxjs/src/index.js
@@ -1,39 +1,37 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-rxjs'
 import { interval } from 'rxjs/observable/interval'
 import { withLatestFrom, map } from 'rxjs/operators'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
-
-const handler = props => effect => {
-    if (effect.type === 'INCREASE') {
-        props.setState(({ count }) => ({ count: count + 1 }))
-    }
-
-    if (effect.type === 'DECREASE') {
-        props.setState(({ count }) => ({ count: count - 1 }))
-    }
-}
 
 const aperture = props => component => {
     const direction$ = component.observe('direction')
-
     const tick$ = interval(1000)
 
-    return tick$.pipe(
-        withLatestFrom(direction$),
-        map(([, type]) => ({ type }))
-    )
+    return tick$.pipe(withLatestFrom(direction$), map(([, type]) => ({ type })))
 }
 
-const initialState = { count: 0, direction: 'NONE' }
+const handler = props => effect => {
+    switch (effect.type) {
+        case 'DECREASE':
+            return props.setState(({ count }) => ({ count: count - 1 }))
 
-const mapSetStateToProps = { setDirection: direction => ({ direction }) }
+        case 'INCREASE':
+            return props.setState(({ count }) => ({ count: count + 1 }))
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+        default:
+            return
+    }
+}
+
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/counter/xstream/package.json
+++ b/examples/counter/xstream/package.json
@@ -1,10 +1,9 @@
 {
     "name": "refract-example-xstream-counter",
     "dependencies": {
-        "react": "16.1.1",
-        "react-dom": "16.1.1",
-        "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
+        "react": "~16.4.2",
+        "react-dom": "~16.4.2",
+        "react-scripts": "~1.1.5",
         "refract-xstream": "~1.0.0",
         "xstream": "~11.7.0"
     },

--- a/examples/counter/xstream/public/style.css
+++ b/examples/counter/xstream/public/style.css
@@ -1,4 +1,6 @@
-html, body, button {
+html,
+body,
+button {
     font-family: Ubuntu, Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 10px;
@@ -14,7 +16,7 @@ p:not(:first-child) {
 }
 
 button {
-    background: #50B979;
+    background: #50b979;
     border: none;
     border-radius: 4px;
     color: #fff;
@@ -22,11 +24,12 @@ button {
     font-size: 1rem;
     line-height: 2;
     outline: none;
-    padding: 0 .5em;
+    padding: 0 0.5em;
 }
 
-button:hover {
-    background: #225BC1;
+button:hover,
+button.active {
+    background: #225bc1;
 }
 
 button + button {

--- a/examples/counter/xstream/src/Layout.js
+++ b/examples/counter/xstream/src/Layout.js
@@ -5,9 +5,24 @@ const Layout = ({ count, direction, setDirection }) => (
         <p>Current count: {count}</p>
         <p>Current direction: {direction}</p>
         <p>
-            <button onClick={() => setDirection('INCREASE')}>Increase</button>
-            <button onClick={() => setDirection('NONE')}>Pause</button>
-            <button onClick={() => setDirection('DECREASE')}>Decrease</button>
+            <button
+                className={direction === 'INCREASE' && 'active'}
+                onClick={() => setDirection('INCREASE')}
+            >
+                Increase
+            </button>
+            <button
+                className={direction === 'NONE' && 'active'}
+                onClick={() => setDirection('NONE')}
+            >
+                Pause
+            </button>
+            <button
+                className={direction === 'DECREASE' && 'active'}
+                onClick={() => setDirection('DECREASE')}
+            >
+                Decrease
+            </button>
         </p>
     </div>
 )

--- a/examples/counter/xstream/src/StateContainer.js
+++ b/examples/counter/xstream/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { count: 0, direction: 'NONE' }
+    setDirection = direction => this.setState({ direction })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { count, direction } = this.state
+        const { setDirection, setState } = this
+
+        return this.props.children({
+            count,
+            direction,
+            setDirection,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/counter/xstream/src/index.js
+++ b/examples/counter/xstream/src/index.js
@@ -1,35 +1,36 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-xstream'
 import xs from 'xstream'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
-
-const handler = props => effect => {
-    if (effect.type === 'INCREASE') {
-        props.setState(({ count }) => ({ count: count + 1 }))
-    }
-
-    if (effect.type === 'DECREASE') {
-        props.setState(({ count }) => ({ count: count - 1 }))
-    }
-}
 
 const aperture = props => component => {
     const direction$ = component.observe('direction')
-
     const tick$ = xs.periodic(1000)
 
     return xs.combine(direction$, tick$).map(([type]) => ({ type }))
 }
 
-const initialState = { count: 0, direction: 'NONE' }
+const handler = props => effect => {
+    switch (effect.type) {
+        case 'DECREASE':
+            return props.setState(({ count }) => ({ count: count - 1 }))
 
-const mapSetStateToProps = { setDirection: direction => ({ direction }) }
+        case 'INCREASE':
+            return props.setState(({ count }) => ({ count: count + 1 }))
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+        default:
+            return
+    }
+}
+
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))


### PR DESCRIPTION
Trying a new approach, removing `react-state-hoc` to reduce the number of unfamiliar things - have replaced it with a `StateContainer` which just passes state and update functions to a render prop. Also not the simplest API, but should hopefully get the point across a little more clearly!

Also updated dependencies and changed handler to a switch statement - think we should go with that for all the examples for now.