### PR TITLE
Examples: use consistent approach

### DIFF
--- a/examples/debounced-fetch/callbag/package.json
+++ b/examples/debounced-fetch/callbag/package.json
@@ -7,7 +7,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-callbag": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/debounced-fetch/callbag/src/StateContainer.js
+++ b/examples/debounced-fetch/callbag/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { data: null, username: '' }
+    setUsername = username => this.setState({ username })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { data, username } = this.state
+        const { setUsername, setState } = this
+
+        return this.props.children({
+            data,
+            username,
+            setUsername,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/debounced-fetch/callbag/src/index.js
+++ b/examples/debounced-fetch/callbag/src/index.js
@@ -1,20 +1,15 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-callbag'
 import fromPromise from 'callbag-from-promise'
 import { debounce } from 'callbag-debounce'
 import { filter, flatten, map, pipe } from 'callbag-basics'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
-const handler = ({ setState }) => effect => {
-    if (effect.type === 'USER_DATA_RECEIVE') {
-        setState({ data: effect.payload })
-    }
-}
-
-const aperture = () => ({ observe }) =>
+const aperture = props => ({ observe }) =>
     pipe(
         observe('username'),
         filter(Boolean),
@@ -30,12 +25,20 @@ const aperture = () => ({ observe }) =>
         map(payload => ({ type: 'USER_DATA_RECEIVE', payload }))
     )
 
-const initialState = { data: null, username: '' }
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'USER_DATA_RECEIVE':
+            return setState({ data: effect.payload })
 
-const mapSetStateToProps = { setUsername: username => ({ username }) }
+        default:
+            return
+    }
+}
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/debounced-fetch/most/package.json
+++ b/examples/debounced-fetch/most/package.json
@@ -5,7 +5,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-most": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/debounced-fetch/most/src/StateContainer.js
+++ b/examples/debounced-fetch/most/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { data: null, username: '' }
+    setUsername = username => this.setState({ username })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { data, username } = this.state
+        const { setUsername, setState } = this
+
+        return this.props.children({
+            data,
+            username,
+            setUsername,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/debounced-fetch/most/src/index.js
+++ b/examples/debounced-fetch/most/src/index.js
@@ -1,18 +1,13 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-most'
 import { fromPromise } from 'most'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
-const handler = ({ setState }) => effect => {
-    if (effect.type === 'USER_DATA_RECEIVE') {
-        setState({ data: effect.payload })
-    }
-}
-
-const aperture = () => ({ observe }) =>
+const aperture = props => ({ observe }) =>
     observe('username')
         .filter(Boolean)
         .debounce(1000)
@@ -24,12 +19,20 @@ const aperture = () => ({ observe }) =>
         .awaitPromises()
         .map(payload => ({ type: 'USER_DATA_RECEIVE', payload }))
 
-const initialState = { data: null, username: '' }
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'USER_DATA_RECEIVE':
+            return setState({ data: effect.payload })
 
-const mapSetStateToProps = { setUsername: username => ({ username }) }
+        default:
+            return
+    }
+}
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/debounced-fetch/rxjs/package.json
+++ b/examples/debounced-fetch/rxjs/package.json
@@ -4,7 +4,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-rxjs": "~1.0.0",
         "rxjs": "~6.2.2",
         "rxjs-compat": "~6.2.2"

--- a/examples/debounced-fetch/rxjs/src/StateContainer.js
+++ b/examples/debounced-fetch/rxjs/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { data: null, username: '' }
+    setUsername = username => this.setState({ username })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { data, username } = this.state
+        const { setUsername, setState } = this
+
+        return this.props.children({
+            data,
+            username,
+            setUsername,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/debounced-fetch/xstream/package.json
+++ b/examples/debounced-fetch/xstream/package.json
@@ -4,7 +4,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-xstream": "~1.0.0",
         "xstream": "~11.7.0"
     },

--- a/examples/debounced-fetch/xstream/src/StateContainer.js
+++ b/examples/debounced-fetch/xstream/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { data: null, username: '' }
+    setUsername = username => this.setState({ username })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { data, username } = this.state
+        const { setUsername, setState } = this
+
+        return this.props.children({
+            data,
+            username,
+            setUsername,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/debounced-fetch/xstream/src/index.js
+++ b/examples/debounced-fetch/xstream/src/index.js
@@ -1,20 +1,14 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-xstream'
 import xs from 'xstream'
 import debounce from 'xstream/extra/debounce'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
-const handler = ({ setState }) => effect => {
-    console.log(effect)
-    if (effect.type === 'USER_DATA_RECEIVE') {
-        setState({ data: effect.payload })
-    }
-}
-
-const aperture = () => ({ observe }) =>
+const aperture = props => ({ observe }) =>
     observe('username')
         .filter(Boolean)
         .compose(debounce(1000))
@@ -28,12 +22,20 @@ const aperture = () => ({ observe }) =>
         .flatten()
         .map(payload => ({ type: 'USER_DATA_RECEIVE', payload }))
 
-const initialState = { data: null, username: '' }
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'USER_DATA_RECEIVE':
+            return setState({ data: effect.payload })
 
-const mapSetStateToProps = { setUsername: username => ({ username }) }
+        default:
+            return
+    }
+}
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/field-validation/callbag/package.json
+++ b/examples/field-validation/callbag/package.json
@@ -7,7 +7,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-callbag": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/field-validation/callbag/src/StateContainer.js
+++ b/examples/field-validation/callbag/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { available: null, username: '' }
+    setAvailable = available => this.setState({ available })
+    setUsername = username => this.setState({ available: null, username })
+
+    render() {
+        const { available, username } = this.state
+        const { setAvailable, setUsername } = this
+
+        return this.props.children({
+            available,
+            username,
+            setAvailable,
+            setUsername
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/field-validation/callbag/src/index.js
+++ b/examples/field-validation/callbag/src/index.js
@@ -1,24 +1,15 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-callbag'
 import fromPromise from 'callbag-from-promise'
 import { debounce } from 'callbag-debounce'
 import { filter, flatten, map, pipe } from 'callbag-basics'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
-const handler = ({ setAvailable }) => effect => {
-    if (effect.type === 'USER_FOUND') {
-        setAvailable('false')
-    } else if (effect.type === 'USERNAME_AVAILABLE') {
-        setAvailable('true')
-    } else {
-        setAvailable(null)
-    }
-}
-
-const aperture = () => ({ observe }) =>
+const aperture = props => ({ observe }) =>
     pipe(
         observe('username'),
         filter(Boolean),
@@ -36,15 +27,23 @@ const aperture = () => ({ observe }) =>
         }))
     )
 
-const initialState = { available: null, username: '' }
+const handler = ({ setAvailable }) => effect => {
+    switch (effect.type) {
+        case 'USER_FOUND':
+            return setAvailable('false')
 
-const mapSetStateToProps = {
-    setAvailable: available => ({ available }),
-    setUsername: username => ({ available: null, username })
+        case 'USERNAME_AVAILABLE':
+            return setAvailable('true')
+
+        default:
+            return setAvailable(null)
+    }
 }
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/field-validation/most/package.json
+++ b/examples/field-validation/most/package.json
@@ -5,7 +5,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-most": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/field-validation/most/src/StateContainer.js
+++ b/examples/field-validation/most/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { available: null, username: '' }
+    setAvailable = available => this.setState({ available })
+    setUsername = username => this.setState({ available: null, username })
+
+    render() {
+        const { available, username } = this.state
+        const { setAvailable, setUsername } = this
+
+        return this.props.children({
+            available,
+            username,
+            setAvailable,
+            setUsername
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/field-validation/most/src/index.js
+++ b/examples/field-validation/most/src/index.js
@@ -1,22 +1,13 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-most'
 import { fromPromise } from 'most'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
-const handler = ({ setAvailable }) => effect => {
-    if (effect.type === 'USER_FOUND') {
-        setAvailable('false')
-    } else if (effect.type === 'USERNAME_AVAILABLE') {
-        setAvailable('true')
-    } else {
-        setAvailable(null)
-    }
-}
-
-const aperture = () => ({ observe }) =>
+const aperture = props => ({ observe }) =>
     observe('username')
         .filter(Boolean)
         .debounce(1000)
@@ -32,15 +23,23 @@ const aperture = () => ({ observe }) =>
             type: message === 'Not Found' ? 'USERNAME_AVAILABLE' : 'USER_FOUND'
         }))
 
-const initialState = { available: null, username: '' }
+const handler = ({ setAvailable }) => effect => {
+    switch (effect.type) {
+        case 'USER_FOUND':
+            return setAvailable('false')
 
-const mapSetStateToProps = {
-    setAvailable: available => ({ available }),
-    setUsername: username => ({ available: null, username })
+        case 'USERNAME_AVAILABLE':
+            return setAvailable('true')
+
+        default:
+            return setAvailable(null)
+    }
 }
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/field-validation/rxjs/package.json
+++ b/examples/field-validation/rxjs/package.json
@@ -4,7 +4,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-rxjs": "~1.0.0",
         "rxjs": "~6.2.2",
         "rxjs-compat": "~6.2.2"

--- a/examples/field-validation/rxjs/src/StateContainer.js
+++ b/examples/field-validation/rxjs/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { available: null, username: '' }
+    setAvailable = available => this.setState({ available })
+    setUsername = username => this.setState({ available: null, username })
+
+    render() {
+        const { available, username } = this.state
+        const { setAvailable, setUsername } = this
+
+        return this.props.children({
+            available,
+            username,
+            setAvailable,
+            setUsername
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/field-validation/rxjs/src/index.js
+++ b/examples/field-validation/rxjs/src/index.js
@@ -1,24 +1,15 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-rxjs'
 import { fromPromise } from 'rxjs/observable/fromPromise'
 import { debounce, filter, flatMap, map } from 'rxjs/operators'
 import { timer } from 'rxjs/observable/timer'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
-const handler = ({ setAvailable }) => effect => {
-    if (effect.type === 'USER_FOUND') {
-        setAvailable('false')
-    } else if (effect.type === 'USERNAME_AVAILABLE') {
-        setAvailable('true')
-    } else {
-        setAvailable(null)
-    }
-}
-
-const aperture = () => ({ observe }) =>
+const aperture = props => ({ observe }) =>
     observe('username').pipe(
         filter(Boolean),
         debounce(() => timer(1000)),
@@ -34,15 +25,23 @@ const aperture = () => ({ observe }) =>
         }))
     )
 
-const initialState = { available: null, username: '' }
+const handler = ({ setAvailable }) => effect => {
+    switch (effect.type) {
+        case 'USER_FOUND':
+            return setAvailable('false')
 
-const mapSetStateToProps = {
-    setAvailable: available => ({ available }),
-    setUsername: username => ({ available: null, username })
+        case 'USERNAME_AVAILABLE':
+            return setAvailable('true')
+
+        default:
+            return setAvailable(null)
+    }
 }
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/field-validation/xstream/package.json
+++ b/examples/field-validation/xstream/package.json
@@ -4,7 +4,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-xstream": "~1.0.0",
         "xstream": "~11.7.0"
     },

--- a/examples/field-validation/xstream/src/StateContainer.js
+++ b/examples/field-validation/xstream/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { available: null, username: '' }
+    setAvailable = available => this.setState({ available })
+    setUsername = username => this.setState({ available: null, username })
+
+    render() {
+        const { available, username } = this.state
+        const { setAvailable, setUsername } = this
+
+        return this.props.children({
+            available,
+            username,
+            setAvailable,
+            setUsername
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/field-validation/xstream/src/index.js
+++ b/examples/field-validation/xstream/src/index.js
@@ -1,23 +1,14 @@
 import React from 'react'
 import { render } from 'react-dom'
-import withState from 'react-state-hoc'
+
 import { withEffects } from 'refract-xstream'
 import xs from 'xstream'
 import debounce from 'xstream/extra/debounce'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
-const handler = ({ setAvailable }) => effect => {
-    if (effect.type === 'USER_FOUND') {
-        setAvailable('false')
-    } else if (effect.type === 'USERNAME_AVAILABLE') {
-        setAvailable('true')
-    } else {
-        setAvailable(null)
-    }
-}
-
-const aperture = () => ({ observe }) =>
+const aperture = props => ({ observe }) =>
     observe('username')
         .filter(Boolean)
         .compose(debounce(1000))
@@ -33,15 +24,23 @@ const aperture = () => ({ observe }) =>
             type: message === 'Not Found' ? 'USERNAME_AVAILABLE' : 'USER_FOUND'
         }))
 
-const initialState = { available: null, username: '' }
+const handler = ({ setAvailable }) => effect => {
+    switch (effect.type) {
+        case 'USER_FOUND':
+            return setAvailable('false')
 
-const mapSetStateToProps = {
-    setAvailable: available => ({ available }),
-    setUsername: username => ({ available: null, username })
+        case 'USERNAME_AVAILABLE':
+            return setAvailable('true')
+
+        default:
+            return setAvailable(null)
+    }
 }
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/redux-fetch/callbag/package.json
+++ b/examples/redux-fetch/callbag/package.json
@@ -7,7 +7,6 @@
         "react-dom": "16.1.1",
         "react-redux": "~5.0.7",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "redux": "~4.0.0",
         "redux-devtools-extension": "~2.13.5",
         "refract-callbag": "~1.0.0",

--- a/examples/redux-fetch/callbag/src/Layout.js
+++ b/examples/redux-fetch/callbag/src/Layout.js
@@ -1,39 +1,20 @@
 import React from 'react'
-import withState from 'react-state-hoc'
 import { connect } from 'react-redux'
 import { actionCreators } from './store'
 
+import Search from './Search'
 import Users from './Users'
 
-const Layout = ({ setUsername, username, requestUser }) => (
+const Layout = ({ requestUser }) => (
     <div>
-        <form
-            className="inline"
-            onSubmit={e => {
-                e.preventDefault()
-                requestUser(username)
-            }}
-        >
-            <input
-                placeholder="Enter a GitHub username..."
-                value={username}
-                onChange={e => setUsername(e.target.value)}
-            />
-            <button type="submit">Search!</button>
-        </form>
+        <Search
+            placeholder="Enter a GitHub username..."
+            onSubmit={requestUser}
+        />
         <Users />
     </div>
 )
 
-const mapDispatchToProps = {
+export default connect(null, {
     requestUser: actionCreators.requestUser
-}
-
-const initialState = { data: null, username: '' }
-
-const mapSetStateToProps = { setUsername: username => ({ username }) }
-
-export default connect(
-    null,
-    mapDispatchToProps
-)(withState(initialState, mapSetStateToProps)(Layout))
+})(Layout)

--- a/examples/redux-fetch/callbag/src/Search.js
+++ b/examples/redux-fetch/callbag/src/Search.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+
+class Search extends Component {
+    state = { query: '' }
+
+    onChange = e => {
+        this.setState({ query: e.target.value })
+    }
+
+    onSubmit = e => {
+        e.preventDefault()
+        this.props.onSubmit && this.props.onSubmit(this.state.query)
+    }
+
+    render() {
+        return (
+            <form className="inline" onSubmit={this.onSubmit}>
+                <input
+                    placeholder={this.props.placeholder}
+                    value={this.state.query}
+                    onChange={this.onChange}
+                />
+                <button type="submit">Search!</button>
+            </form>
+        )
+    }
+}
+
+export default Search

--- a/examples/redux-fetch/callbag/src/Users.js
+++ b/examples/redux-fetch/callbag/src/Users.js
@@ -20,7 +20,7 @@ const Users = ({ active, selectUser, users }) => {
     const userLinks = Object.values(users).map(user => (
         <UserLink
             key={user.login}
-            selectUser={selectUser(user.login)}
+            selectUser={() => selectUser(user.login)}
             active={active === user.login}
             {...user}
         />
@@ -41,11 +41,8 @@ const mapStateToProps = state => ({
     active: selectors.getActive(state),
     users: selectors.getUsers(state)
 })
-const mapDispatchToProps = dispatch => ({
-    selectUser: userId => () => dispatch(actionCreators.selectUser(userId))
-})
+const mapDispatchToProps = {
+    selectUser: actionCreators.selectUser
+}
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(Users)
+export default connect(mapStateToProps, mapDispatchToProps)(Users)

--- a/examples/redux-fetch/callbag/src/index.js
+++ b/examples/redux-fetch/callbag/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
+
 import { withEffects } from 'refract-callbag'
 import fromPromise from 'callbag-from-promise'
 import { filter, flatten, map, merge, combine, pipe } from 'callbag-basics'
@@ -9,21 +10,7 @@ import Layout from './Layout'
 import { actionCreators, actionTypes, selectors } from './store'
 import store from './setupStore'
 
-const handler = ({ store }) => effect => {
-    if (effect.type === actionTypes.ERROR_RECEIVE) {
-        console.log(effect)
-    }
-
-    if (effect.type === actionTypes.USER_RECEIVE) {
-        store.dispatch(effect)
-    }
-
-    if (effect.type === actionTypes.USER_SELECT) {
-        store.dispatch(effect)
-    }
-}
-
-const aperture = ({ store }) => () => {
+const aperture = ({ store }) => component => {
     const combined$ = combine(
         store.observe(actionTypes.USER_REQUEST),
         store.observe(selectors.getUsers)
@@ -56,6 +43,22 @@ const aperture = ({ store }) => () => {
     )
 
     return merge(requestUser$, selectUser$)
+}
+
+const handler = ({ store }) => effect => {
+    switch (effect.type) {
+        case actionTypes.ERROR_RECEIVE:
+            return console.log(effect)
+
+        case actionTypes.USER_RECEIVE:
+            return store.dispatch(effect)
+
+        case actionTypes.USER_SELECT:
+            return store.dispatch(effect)
+
+        default:
+            return
+    }
 }
 
 const App = withEffects(handler)(aperture)(Layout)

--- a/examples/redux-fetch/most/package.json
+++ b/examples/redux-fetch/most/package.json
@@ -6,7 +6,6 @@
         "react-dom": "16.1.1",
         "react-redux": "5.0.7",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "redux": "4.0.0",
         "redux-devtools-extension": "~2.13.5",
         "refract-most": "~1.0.0",

--- a/examples/redux-fetch/most/src/Layout.js
+++ b/examples/redux-fetch/most/src/Layout.js
@@ -1,39 +1,20 @@
 import React from 'react'
-import withState from 'react-state-hoc'
 import { connect } from 'react-redux'
 import { actionCreators } from './store'
 
+import Search from './Search'
 import Users from './Users'
 
-const Layout = ({ setUsername, username, requestUser }) => (
+const Layout = ({ requestUser }) => (
     <div>
-        <form
-            className="inline"
-            onSubmit={e => {
-                e.preventDefault()
-                requestUser(username)
-            }}
-        >
-            <input
-                placeholder="Enter a GitHub username..."
-                value={username}
-                onChange={e => setUsername(e.target.value)}
-            />
-            <button type="submit">Search!</button>
-        </form>
+        <Search
+            placeholder="Enter a GitHub username..."
+            onSubmit={requestUser}
+        />
         <Users />
     </div>
 )
 
-const mapDispatchToProps = {
+export default connect(null, {
     requestUser: actionCreators.requestUser
-}
-
-const initialState = { data: null, username: '' }
-
-const mapSetStateToProps = { setUsername: username => ({ username }) }
-
-export default connect(
-    null,
-    mapDispatchToProps
-)(withState(initialState, mapSetStateToProps)(Layout))
+})(Layout)

--- a/examples/redux-fetch/most/src/Search.js
+++ b/examples/redux-fetch/most/src/Search.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+
+class Search extends Component {
+    state = { query: '' }
+
+    onChange = e => {
+        this.setState({ query: e.target.value })
+    }
+
+    onSubmit = e => {
+        e.preventDefault()
+        this.props.onSubmit && this.props.onSubmit(this.state.query)
+    }
+
+    render() {
+        return (
+            <form className="inline" onSubmit={this.onSubmit}>
+                <input
+                    placeholder={this.props.placeholder}
+                    value={this.state.query}
+                    onChange={this.onChange}
+                />
+                <button type="submit">Search!</button>
+            </form>
+        )
+    }
+}
+
+export default Search

--- a/examples/redux-fetch/most/src/Users.js
+++ b/examples/redux-fetch/most/src/Users.js
@@ -20,7 +20,7 @@ const Users = ({ active, selectUser, users }) => {
     const userLinks = Object.values(users).map(user => (
         <UserLink
             key={user.login}
-            selectUser={selectUser(user.login)}
+            selectUser={() => selectUser(user.login)}
             active={active === user.login}
             {...user}
         />
@@ -41,11 +41,8 @@ const mapStateToProps = state => ({
     active: selectors.getActive(state),
     users: selectors.getUsers(state)
 })
-const mapDispatchToProps = dispatch => ({
-    selectUser: userId => () => dispatch(actionCreators.selectUser(userId))
-})
+const mapDispatchToProps = {
+    selectUser: actionCreators.selectUser
+}
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(Users)
+export default connect(mapStateToProps, mapDispatchToProps)(Users)

--- a/examples/redux-fetch/most/src/index.js
+++ b/examples/redux-fetch/most/src/index.js
@@ -1,26 +1,13 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
+
 import { withEffects } from 'refract-most'
 import { combine, fromPromise, merge } from 'most'
 
 import Layout from './Layout'
 import { actionCreators, actionTypes, selectors } from './store'
 import store from './setupStore'
-
-const handler = ({ store }) => effect => {
-    if (effect.type === actionTypes.ERROR_RECEIVE) {
-        console.log(effect)
-    }
-
-    if (effect.type === actionTypes.USER_RECEIVE) {
-        store.dispatch(effect)
-    }
-
-    if (effect.type === actionTypes.USER_SELECT) {
-        store.dispatch(effect)
-    }
-}
 
 const aperture = ({ store }) => component => {
     const combined$ = combine(
@@ -52,6 +39,22 @@ const aperture = ({ store }) => component => {
         .map(actionCreators.selectUser)
 
     return merge(requestUser$, selectUser$)
+}
+
+const handler = ({ store }) => effect => {
+    switch (effect.type) {
+        case actionTypes.ERROR_RECEIVE:
+            return console.log(effect)
+
+        case actionTypes.USER_RECEIVE:
+            return store.dispatch(effect)
+
+        case actionTypes.USER_SELECT:
+            return store.dispatch(effect)
+
+        default:
+            return
+    }
 }
 
 const App = withEffects(handler)(aperture)(Layout)

--- a/examples/redux-fetch/rxjs/package.json
+++ b/examples/redux-fetch/rxjs/package.json
@@ -5,7 +5,6 @@
         "react-dom": "16.1.1",
         "react-redux": "~5.0.7",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "redux": "~4.0.0",
         "redux-devtools-extension": "~2.13.5",
         "refract-redux-rxjs": "~1.0.0",

--- a/examples/redux-fetch/rxjs/src/Layout.js
+++ b/examples/redux-fetch/rxjs/src/Layout.js
@@ -1,39 +1,20 @@
 import React from 'react'
-import withState from 'react-state-hoc'
 import { connect } from 'react-redux'
 import { actionCreators } from './store'
 
+import Search from './Search'
 import Users from './Users'
 
-const Layout = ({ setUsername, username, requestUser }) => (
+const Layout = ({ requestUser }) => (
     <div>
-        <form
-            className="inline"
-            onSubmit={e => {
-                e.preventDefault()
-                requestUser(username)
-            }}
-        >
-            <input
-                placeholder="Enter a GitHub username..."
-                value={username}
-                onChange={e => setUsername(e.target.value)}
-            />
-            <button type="submit">Search!</button>
-        </form>
+        <Search
+            placeholder="Enter a GitHub username..."
+            onSubmit={requestUser}
+        />
         <Users />
     </div>
 )
 
-const mapDispatchToProps = {
+export default connect(null, {
     requestUser: actionCreators.requestUser
-}
-
-const initialState = { data: null, username: '' }
-
-const mapSetStateToProps = { setUsername: username => ({ username }) }
-
-export default connect(
-    null,
-    mapDispatchToProps
-)(withState(initialState, mapSetStateToProps)(Layout))
+})(Layout)

--- a/examples/redux-fetch/rxjs/src/Search.js
+++ b/examples/redux-fetch/rxjs/src/Search.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+
+class Search extends Component {
+    state = { query: '' }
+
+    onChange = e => {
+        this.setState({ query: e.target.value })
+    }
+
+    onSubmit = e => {
+        e.preventDefault()
+        this.props.onSubmit && this.props.onSubmit(this.state.query)
+    }
+
+    render() {
+        return (
+            <form className="inline" onSubmit={this.onSubmit}>
+                <input
+                    placeholder={this.props.placeholder}
+                    value={this.state.query}
+                    onChange={this.onChange}
+                />
+                <button type="submit">Search!</button>
+            </form>
+        )
+    }
+}
+
+export default Search

--- a/examples/redux-fetch/rxjs/src/Users.js
+++ b/examples/redux-fetch/rxjs/src/Users.js
@@ -20,7 +20,7 @@ const Users = ({ active, selectUser, users }) => {
     const userLinks = Object.values(users).map(user => (
         <UserLink
             key={user.login}
-            selectUser={selectUser(user.login)}
+            selectUser={() => selectUser(user.login)}
             active={active === user.login}
             {...user}
         />
@@ -41,11 +41,8 @@ const mapStateToProps = state => ({
     active: selectors.getActive(state),
     users: selectors.getUsers(state)
 })
-const mapDispatchToProps = dispatch => ({
-    selectUser: userId => () => dispatch(actionCreators.selectUser(userId))
-})
+const mapDispatchToProps = {
+    selectUser: actionCreators.selectUser
+}
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(Users)
+export default connect(mapStateToProps, mapDispatchToProps)(Users)

--- a/examples/redux-fetch/rxjs/src/index.js
+++ b/examples/redux-fetch/rxjs/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
+
 import { withEffects } from 'refract-rxjs'
 import { filter, map, mergeMap } from 'rxjs/operators'
 import { combineLatest } from 'rxjs/observable/combineLatest'
@@ -11,21 +12,7 @@ import Layout from './Layout'
 import { actionCreators, actionTypes, selectors } from './store'
 import store from './setupStore'
 
-const handler = ({ store }) => effect => {
-    if (effect.type === actionTypes.ERROR_RECEIVE) {
-        console.log(effect)
-    }
-
-    if (effect.type === actionTypes.USER_RECEIVE) {
-        store.dispatch(effect)
-    }
-
-    if (effect.type === actionTypes.USER_SELECT) {
-        store.dispatch(effect)
-    }
-}
-
-const aperture = ({ store }) => () => {
+const aperture = ({ store }) => component => {
     const combined$ = combineLatest(
         store.observe(actionTypes.USER_REQUEST),
         store.observe(selectors.getUsers)
@@ -55,6 +42,22 @@ const aperture = ({ store }) => () => {
     )
 
     return merge(requestUser$, selectUser$)
+}
+
+const handler = ({ store }) => effect => {
+    switch (effect.type) {
+        case actionTypes.ERROR_RECEIVE:
+            return console.log(effect)
+
+        case actionTypes.USER_RECEIVE:
+            return store.dispatch(effect)
+
+        case actionTypes.USER_SELECT:
+            return store.dispatch(effect)
+
+        default:
+            return
+    }
 }
 
 const App = withEffects(handler)(aperture)(Layout)

--- a/examples/redux-fetch/xstream/package.json
+++ b/examples/redux-fetch/xstream/package.json
@@ -5,7 +5,6 @@
         "react-dom": "16.1.1",
         "react-redux": "~5.0.7",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "redux": "~4.0.0",
         "redux-devtools-extension": "~2.13.5",
         "refract-redux-xstream": "~1.0.0",

--- a/examples/redux-fetch/xstream/src/Layout.js
+++ b/examples/redux-fetch/xstream/src/Layout.js
@@ -1,39 +1,20 @@
 import React from 'react'
-import withState from 'react-state-hoc'
 import { connect } from 'react-redux'
 import { actionCreators } from './store'
 
+import Search from './Search'
 import Users from './Users'
 
-const Layout = ({ setUsername, username, requestUser }) => (
+const Layout = ({ requestUser }) => (
     <div>
-        <form
-            className="inline"
-            onSubmit={e => {
-                e.preventDefault()
-                requestUser(username)
-            }}
-        >
-            <input
-                placeholder="Enter a GitHub username..."
-                value={username}
-                onChange={e => setUsername(e.target.value)}
-            />
-            <button type="submit">Search!</button>
-        </form>
+        <Search
+            placeholder="Enter a GitHub username..."
+            onSubmit={requestUser}
+        />
         <Users />
     </div>
 )
 
-const mapDispatchToProps = {
+export default connect(null, {
     requestUser: actionCreators.requestUser
-}
-
-const initialState = { data: null, username: '' }
-
-const mapSetStateToProps = { setUsername: username => ({ username }) }
-
-export default connect(
-    null,
-    mapDispatchToProps
-)(withState(initialState, mapSetStateToProps)(Layout))
+})(Layout)

--- a/examples/redux-fetch/xstream/src/Search.js
+++ b/examples/redux-fetch/xstream/src/Search.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+
+class Search extends Component {
+    state = { query: '' }
+
+    onChange = e => {
+        this.setState({ query: e.target.value })
+    }
+
+    onSubmit = e => {
+        e.preventDefault()
+        this.props.onSubmit && this.props.onSubmit(this.state.query)
+    }
+
+    render() {
+        return (
+            <form className="inline" onSubmit={this.onSubmit}>
+                <input
+                    placeholder={this.props.placeholder}
+                    value={this.state.query}
+                    onChange={this.onChange}
+                />
+                <button type="submit">Search!</button>
+            </form>
+        )
+    }
+}
+
+export default Search

--- a/examples/redux-fetch/xstream/src/Users.js
+++ b/examples/redux-fetch/xstream/src/Users.js
@@ -20,7 +20,7 @@ const Users = ({ active, selectUser, users }) => {
     const userLinks = Object.values(users).map(user => (
         <UserLink
             key={user.login}
-            selectUser={selectUser(user.login)}
+            selectUser={() => selectUser(user.login)}
             active={active === user.login}
             {...user}
         />
@@ -41,11 +41,8 @@ const mapStateToProps = state => ({
     active: selectors.getActive(state),
     users: selectors.getUsers(state)
 })
-const mapDispatchToProps = dispatch => ({
-    selectUser: userId => () => dispatch(actionCreators.selectUser(userId))
-})
+const mapDispatchToProps = {
+    selectUser: actionCreators.selectUser
+}
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(Users)
+export default connect(mapStateToProps, mapDispatchToProps)(Users)

--- a/examples/redux-fetch/xstream/src/index.js
+++ b/examples/redux-fetch/xstream/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
+
 import { withEffects } from 'refract-xstream'
 import xs from 'xstream'
 
@@ -8,21 +9,7 @@ import Layout from './Layout'
 import { actionCreators, actionTypes, selectors } from './store'
 import store from './setupStore'
 
-const handler = ({ store }) => effect => {
-    if (effect.type === actionTypes.ERROR_RECEIVE) {
-        console.log(effect)
-    }
-
-    if (effect.type === actionTypes.USER_RECEIVE) {
-        store.dispatch(effect)
-    }
-
-    if (effect.type === actionTypes.USER_SELECT) {
-        store.dispatch(effect)
-    }
-}
-
-const aperture = ({ store }) => () => {
+const aperture = ({ store }) => component => {
     const combined$ = xs.combine(
         store.observe(actionTypes.USER_REQUEST),
         store.observe(selectors.getUsers)
@@ -51,6 +38,22 @@ const aperture = ({ store }) => () => {
         .map(actionCreators.selectUser)
 
     return xs.merge(requestUser$, selectUser$)
+}
+
+const handler = ({ store }) => effect => {
+    switch (effect.type) {
+        case actionTypes.ERROR_RECEIVE:
+            return console.log(effect)
+
+        case actionTypes.USER_RECEIVE:
+            return store.dispatch(effect)
+
+        case actionTypes.USER_SELECT:
+            return store.dispatch(effect)
+
+        default:
+            return
+    }
 }
 
 const App = withEffects(handler)(aperture)(Layout)

--- a/examples/routing/callbag/package.json
+++ b/examples/routing/callbag/package.json
@@ -6,7 +6,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-callbag": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/routing/callbag/src/StateContainer.js
+++ b/examples/routing/callbag/src/StateContainer.js
@@ -1,0 +1,20 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { activeTab: null }
+    setActiveTab = activeTab => this.setState({ activeTab })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { activeTab } = this.state
+        const { setActiveTab, setState } = this
+
+        return this.props.children({
+            activeTab,
+            setActiveTab,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/routing/callbag/src/index.js
+++ b/examples/routing/callbag/src/index.js
@@ -1,26 +1,12 @@
 import React from 'react'
 import { render } from 'react-dom'
+
 import { withEffects } from 'refract-callbag'
 import { fromEvent, map, merge, pipe } from 'callbag-basics'
 import of from 'callbag-of'
-import withState from 'react-state-hoc'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
-
-const handler = ({ setState }) => (effect = {}) => {
-    if (effect.type === 'NAVIGATION') {
-        const path = document.location.pathname
-        const search = effect.state.activeTab
-            ? `?tab=${effect.state.activeTab}`
-            : ''
-        const methodName = effect.replace ? 'replaceState' : 'pushState'
-        window.history[methodName](effect.state, null, `${path}${search}`)
-    }
-
-    if (effect.type === 'STATE') {
-        setState(effect.state)
-    }
-}
 
 const aperture = initialProps => component => {
     const activeTab$ = component.observe('setActiveTab')
@@ -51,12 +37,29 @@ const aperture = initialProps => component => {
     )
 }
 
-const initialState = { activeTab: null }
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'NAVIGATION':
+            const path = document.location.pathname
+            const search = effect.state.activeTab
+                ? `?tab=${effect.state.activeTab}`
+                : ''
+            const methodName = effect.replace ? 'replaceState' : 'pushState'
+            window.history[methodName](effect.state, null, `${path}${search}`)
+            return
 
-const mapSetStateToProps = { setActiveTab: activeTab => ({ activeTab }) }
+        case 'STATE':
+            return setState(effect.state)
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+        default:
+            return
+    }
+}
+
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/routing/most/package.json
+++ b/examples/routing/most/package.json
@@ -5,7 +5,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-most": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/routing/most/src/StateContainer.js
+++ b/examples/routing/most/src/StateContainer.js
@@ -1,0 +1,20 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { activeTab: null }
+    setActiveTab = activeTab => this.setState({ activeTab })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { activeTab } = this.state
+        const { setActiveTab, setState } = this
+
+        return this.props.children({
+            activeTab,
+            setActiveTab,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/routing/rxjs/package.json
+++ b/examples/routing/rxjs/package.json
@@ -4,7 +4,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-rxjs": "~1.0.0",
         "rxjs": "~6.2.2",
         "rxjs-compat": "~6.2.2"

--- a/examples/routing/rxjs/src/StateContainer.js
+++ b/examples/routing/rxjs/src/StateContainer.js
@@ -1,0 +1,20 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { activeTab: null }
+    setActiveTab = activeTab => this.setState({ activeTab })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { activeTab } = this.state
+        const { setActiveTab, setState } = this
+
+        return this.props.children({
+            activeTab,
+            setActiveTab,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/routing/xstream/package.json
+++ b/examples/routing/xstream/package.json
@@ -4,7 +4,6 @@
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~2.0.0",
         "refract-xstream": "~1.0.0",
         "xstream": "~11.7.0"
     },

--- a/examples/routing/xstream/src/StateContainer.js
+++ b/examples/routing/xstream/src/StateContainer.js
@@ -1,0 +1,20 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { activeTab: null }
+    setActiveTab = activeTab => this.setState({ activeTab })
+    setState = this.setState.bind(this)
+
+    render() {
+        const { activeTab } = this.state
+        const { setActiveTab, setState } = this
+
+        return this.props.children({
+            activeTab,
+            setActiveTab,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/routing/xstream/src/index.js
+++ b/examples/routing/xstream/src/index.js
@@ -1,26 +1,12 @@
 import React from 'react'
 import { render } from 'react-dom'
+
 import { withEffects } from 'refract-xstream'
 import fromEvent from 'xstream/extra/fromEvent'
-import withState from 'react-state-hoc'
 import xs from 'xstream'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
-
-const handler = ({ setState }) => (effect = {}) => {
-    if (effect.type === 'NAVIGATION') {
-        const path = document.location.pathname
-        const search = effect.state.activeTab
-            ? `?tab=${effect.state.activeTab}`
-            : ''
-        const methodName = effect.replace ? 'replaceState' : 'pushState'
-        window.history[methodName](effect.state, null, `${path}${search}`)
-    }
-
-    if (effect.type === 'STATE') {
-        setState(effect.state)
-    }
-}
 
 const aperture = initialProps => component => {
     const activeTab$ = component.observe('setActiveTab')
@@ -45,12 +31,29 @@ const aperture = initialProps => component => {
     )
 }
 
-const initialState = { activeTab: null }
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'NAVIGATION':
+            const path = document.location.pathname
+            const search = effect.state.activeTab
+                ? `?tab=${effect.state.activeTab}`
+                : ''
+            const methodName = effect.replace ? 'replaceState' : 'pushState'
+            window.history[methodName](effect.state, null, `${path}${search}`)
+            return
 
-const mapSetStateToProps = { setActiveTab: activeTab => ({ activeTab }) }
+        case 'STATE':
+            return setState(effect.state)
 
-const App = withState(initialState, mapSetStateToProps)(
-    withEffects(handler)(aperture)(Layout)
+        default:
+            return
+    }
+}
+
+const LayoutWithEffects = withEffects(handler)(aperture)(Layout)
+
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
 render(<App />, document.getElementById('root'))

--- a/examples/typeahead/callbag/package.json
+++ b/examples/typeahead/callbag/package.json
@@ -7,7 +7,6 @@
         "react": "16.4.1",
         "react-dom": "16.4.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-callbag": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/typeahead/callbag/src/StateContainer.js
+++ b/examples/typeahead/callbag/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { search: '', selection: '', sugestions: [], user: null }
+    setState = this.setState.bind(this)
+
+    render() {
+        const { search, selection, suggestions, user } = this.state
+        const { setState } = this
+
+        return this.props.children({
+            search,
+            selection,
+            suggestions,
+            user,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/typeahead/callbag/src/index.js
+++ b/examples/typeahead/callbag/src/index.js
@@ -1,16 +1,17 @@
 import React from 'react'
 import { render } from 'react-dom'
+
 import { withEffects } from 'refract-callbag'
-import withState from 'react-state-hoc'
 import fromPromise from 'callbag-from-promise'
 import { debounce } from 'callbag-debounce'
 import { filter, flatten, map, merge, pipe } from 'callbag-basics'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
 const toState = payload => ({ type: 'SET_STATE', payload })
 
-const aperture = intialProps => component => {
+const aperture = props => component => {
     const search$ = component.observe('search')
 
     const suggestions$ = pipe(
@@ -56,17 +57,21 @@ const aperture = intialProps => component => {
     return merge(suggestions$, clearSuggestions$, user$)
 }
 
-const handler = initialProps => effect => {
-    if (effect.type === 'SET_STATE') {
-        initialProps.setState(effect.payload)
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'SET_STATE':
+            return setState(effect.payload)
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)
 
-const initialState = { search: '', selection: '', sugestions: [], user: null }
+const LayoutWithEffects = withEffects(handler, errorHandler)(aperture)(Layout)
 
-const AppWithEffects = withState(initialState)(
-    withEffects(handler, errorHandler)(aperture)(Layout)
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
-render(<AppWithEffects />, document.getElementById('root'))
+render(<App />, document.getElementById('root'))

--- a/examples/typeahead/most/package.json
+++ b/examples/typeahead/most/package.json
@@ -5,7 +5,6 @@
         "react": "16.4.1",
         "react-dom": "16.4.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-most": "~1.0.0"
     },
     "version": "0.0.0",

--- a/examples/typeahead/most/src/StateContainer.js
+++ b/examples/typeahead/most/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { search: '', selection: '', sugestions: [], user: null }
+    setState = this.setState.bind(this)
+
+    render() {
+        const { search, selection, suggestions, user } = this.state
+        const { setState } = this
+
+        return this.props.children({
+            search,
+            selection,
+            suggestions,
+            user,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/typeahead/most/src/index.js
+++ b/examples/typeahead/most/src/index.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import { render } from 'react-dom'
+
 import { withEffects } from 'refract-most'
-import withState from 'react-state-hoc'
 import { fromPromise, merge } from 'most'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
 const toState = payload => ({ type: 'SET_STATE', payload })
 
-const aperture = intialProps => component => {
+const aperture = props => component => {
     const search$ = component.observe('search')
 
     const suggestions$ = search$
@@ -49,17 +50,21 @@ const aperture = intialProps => component => {
     return merge(suggestions$, clearSuggestions$, user$)
 }
 
-const handler = initialProps => effect => {
-    if (effect.type === 'SET_STATE') {
-        initialProps.setState(effect.payload)
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'SET_STATE':
+            return setState(effect.payload)
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)
 
-const initialState = { search: '', selection: '', sugestions: [], user: null }
+const LayoutWithEffects = withEffects(handler, errorHandler)(aperture)(Layout)
 
-const AppWithEffects = withState(initialState)(
-    withEffects(handler, errorHandler)(aperture)(Layout)
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
-render(<AppWithEffects />, document.getElementById('root'))
+render(<App />, document.getElementById('root'))

--- a/examples/typeahead/rxjs/package.json
+++ b/examples/typeahead/rxjs/package.json
@@ -4,7 +4,6 @@
         "react": "16.4.1",
         "react-dom": "16.4.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-rxjs": "~1.0.0",
         "rxjs": "~6.2.2",
         "rxjs-compat": "~6.2.2"

--- a/examples/typeahead/rxjs/src/StateContainer.js
+++ b/examples/typeahead/rxjs/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { search: '', selection: '', sugestions: [], user: null }
+    setState = this.setState.bind(this)
+
+    render() {
+        const { search, selection, suggestions, user } = this.state
+        const { setState } = this
+
+        return this.props.children({
+            search,
+            selection,
+            suggestions,
+            user,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/typeahead/rxjs/src/index.js
+++ b/examples/typeahead/rxjs/src/index.js
@@ -1,17 +1,18 @@
 import React from 'react'
 import { render } from 'react-dom'
+
 import { withEffects } from 'refract-rxjs'
-import withState from 'react-state-hoc'
 import { fromPromise } from 'rxjs/observable/fromPromise'
 import { debounce, filter, flatMap, map } from 'rxjs/operators'
 import { merge } from 'rxjs/observable/merge'
 import { timer } from 'rxjs/observable/timer'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
 const toState = payload => ({ type: 'SET_STATE', payload })
 
-const aperture = intialProps => component => {
+const aperture = props => component => {
     const search$ = component.observe('search')
 
     const suggestions$ = search$.pipe(
@@ -54,17 +55,21 @@ const aperture = intialProps => component => {
     return merge(suggestions$, clearSuggestions$, user$)
 }
 
-const handler = initialProps => effect => {
-    if (effect.type === 'SET_STATE') {
-        initialProps.setState(effect.payload)
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'SET_STATE':
+            return setState(effect.payload)
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)
 
-const initialState = { search: '', selection: '', sugestions: [], user: null }
+const LayoutWithEffects = withEffects(handler, errorHandler)(aperture)(Layout)
 
-const AppWithEffects = withState(initialState)(
-    withEffects(handler, errorHandler)(aperture)(Layout)
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
-render(<AppWithEffects />, document.getElementById('root'))
+render(<App />, document.getElementById('root'))

--- a/examples/typeahead/xstream/package.json
+++ b/examples/typeahead/xstream/package.json
@@ -4,7 +4,6 @@
         "react": "16.4.1",
         "react-dom": "16.4.1",
         "react-scripts": "1.0.10",
-        "react-state-hoc": "~3.0.0",
         "refract-xstream": "~1.0.0",
         "xstream": "~11.7.0"
     },

--- a/examples/typeahead/xstream/src/StateContainer.js
+++ b/examples/typeahead/xstream/src/StateContainer.js
@@ -1,0 +1,21 @@
+import { Component } from 'react'
+
+class StateContainer extends Component {
+    state = { search: '', selection: '', sugestions: [], user: null }
+    setState = this.setState.bind(this)
+
+    render() {
+        const { search, selection, suggestions, user } = this.state
+        const { setState } = this
+
+        return this.props.children({
+            search,
+            selection,
+            suggestions,
+            user,
+            setState
+        })
+    }
+}
+
+export default StateContainer

--- a/examples/typeahead/xstream/src/index.js
+++ b/examples/typeahead/xstream/src/index.js
@@ -1,15 +1,16 @@
 import React from 'react'
 import { render } from 'react-dom'
+
 import { withEffects } from 'refract-xstream'
-import withState from 'react-state-hoc'
 import xs from 'xstream'
 import debounce from 'xstream/extra/debounce'
 
+import StateContainer from './StateContainer'
 import Layout from './Layout'
 
 const toState = payload => ({ type: 'SET_STATE', payload })
 
-const aperture = intialProps => component => {
+const aperture = props => component => {
     const search$ = component.observe('search')
 
     const suggestions$ = search$
@@ -50,17 +51,21 @@ const aperture = intialProps => component => {
     return xs.merge(suggestions$, clearSuggestions$, user$)
 }
 
-const handler = initialProps => effect => {
-    if (effect.type === 'SET_STATE') {
-        initialProps.setState(effect.payload)
+const handler = ({ setState }) => effect => {
+    switch (effect.type) {
+        case 'SET_STATE':
+            return setState(effect.payload)
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)
 
-const initialState = { search: '', selection: '', sugestions: [], user: null }
+const LayoutWithEffects = withEffects(handler, errorHandler)(aperture)(Layout)
 
-const AppWithEffects = withState(initialState)(
-    withEffects(handler, errorHandler)(aperture)(Layout)
+const App = () => (
+    <StateContainer>{state => <LayoutWithEffects {...state} />}</StateContainer>
 )
 
-render(<AppWithEffects />, document.getElementById('root'))
+render(<App />, document.getElementById('root'))

--- a/examples/visit-time/callbag/src/index.js
+++ b/examples/visit-time/callbag/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import withState from 'react-state-hoc'
+
 import { withEffects, compose } from 'refract-callbag'
 import { merge, combine, fromEvent, pipe, map, flatten } from 'callbag-basics'
 import startWith from 'callbag-start-with'
@@ -21,14 +22,8 @@ const aperture = () => component => {
     )
     const online$ = pipe(
         merge(
-            pipe(
-                fromEvent(window, 'online'),
-                map(() => true)
-            ),
-            pipe(
-                fromEvent(window, 'offline'),
-                map(() => false)
-            )
+            pipe(fromEvent(window, 'online'), map(() => true)),
+            pipe(fromEvent(window, 'offline'), map(() => false))
         ),
         startWith(isOnline())
     )
@@ -54,12 +49,18 @@ const aperture = () => component => {
 }
 
 const handler = ({ resume, pause, tick }) => effect => {
-    if (effect.type === 'RESUME') {
-        resume(Date.now())
-    } else if (effect.type === 'PAUSE') {
-        pause(Date.now())
-    } else if (effect.type === 'TICK') {
-        tick(Date.now())
+    switch (effect.type) {
+        case 'RESUME':
+            return resume(Date.now())
+
+        case 'PAUSE':
+            return pause(Date.now())
+
+        case 'TICK':
+            return tick(Date.now())
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)

--- a/examples/visit-time/most/src/index.js
+++ b/examples/visit-time/most/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import withState from 'react-state-hoc'
+
 import { withEffects, compose } from 'refract-most'
 import { combine, merge, fromEvent, of as MostOf, periodic } from 'most'
 
@@ -34,12 +35,18 @@ const aperture = () => component => {
 }
 
 const handler = ({ resume, pause, tick }) => effect => {
-    if (effect.type === 'RESUME') {
-        resume(Date.now())
-    } else if (effect.type === 'PAUSE') {
-        pause(Date.now())
-    } else if (effect.type === 'TICK') {
-        tick(Date.now())
+    switch (effect.type) {
+        case 'RESUME':
+            return resume(Date.now())
+
+        case 'PAUSE':
+            return pause(Date.now())
+
+        case 'TICK':
+            return tick(Date.now())
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)

--- a/examples/visit-time/rxjs/src/index.js
+++ b/examples/visit-time/rxjs/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import withState from 'react-state-hoc'
+
 import { withEffects, compose } from 'refract-rxjs'
 import { fromEvent, merge, combineLatest, interval, of as RxOf } from 'rxjs'
 import {
@@ -45,12 +46,18 @@ const aperture = () => component => {
 }
 
 const handler = ({ resume, pause, tick }) => effect => {
-    if (effect.type === 'RESUME') {
-        resume(Date.now())
-    } else if (effect.type === 'PAUSE') {
-        pause(Date.now())
-    } else if (effect.type === 'TICK') {
-        tick(Date.now())
+    switch (effect.type) {
+        case 'RESUME':
+            return resume(Date.now())
+
+        case 'PAUSE':
+            return pause(Date.now())
+
+        case 'TICK':
+            return tick(Date.now())
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)

--- a/examples/visit-time/xstream/src/index.js
+++ b/examples/visit-time/xstream/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import withState from 'react-state-hoc'
+
 import { withEffects, compose } from 'refract-xstream'
 import xs from 'xstream'
 import fromEvent from 'xstream/extra/fromEvent'
@@ -41,12 +42,18 @@ const aperture = () => component => {
 }
 
 const handler = ({ resume, pause, tick }) => effect => {
-    if (effect.type === 'RESUME') {
-        resume(Date.now())
-    } else if (effect.type === 'PAUSE') {
-        pause(Date.now())
-    } else if (effect.type === 'TICK') {
-        tick(Date.now())
+    switch (effect.type) {
+        case 'RESUME':
+            return resume(Date.now())
+
+        case 'PAUSE':
+            return pause(Date.now())
+
+        case 'TICK':
+            return tick(Date.now())
+
+        default:
+            return
     }
 }
 const errorHandler = () => err => console.error(err)


### PR DESCRIPTION
Refactored as per the approach used in #68.

Main changes are:

- **Use a switch statement in the `effectHandler`** - this style reminds people of reducers, which helps quickly build a mental model of the separation of concerns.
- **Remove `react-state-hoc`** - a few people mentioned that using the HoC was an extra layer of stuff for them to grasp, so better to leave it out for the current examples. I've left it in for the `visit-time` example, think we should include it in some more advanced examples!