### PR TITLE
Make connecting to react doc clearer

### DIFF
--- a/docs/usage/connecting-to-react.md
+++ b/docs/usage/connecting-to-react.md
@@ -27,6 +27,12 @@ If we want to cause side-effects in response to changes in the props being passe
 ```js
 import { withEffects } from 'refract-rxjs'
 
+// Note that the handler and aperture are explained later in the docs,
+// these empty functions are just placeholders
+const aperture = () => {}
+const handler = () => {}
+//
+
 const CounterWithEffects = withEffects(handler)(aperture)(Counter)
 ```
 

--- a/docs/usage/connecting-to-react.md
+++ b/docs/usage/connecting-to-react.md
@@ -29,8 +29,8 @@ import { withEffects } from 'refract-rxjs'
 
 // Note that the handler and aperture are explained later in the docs,
 // these empty functions are just placeholders
-const aperture = () => {}
-const handler = () => {}
+const aperture = initialProps => component => {}
+const handler = initialProps => effect => {}
 //
 
 const CounterWithEffects = withEffects(handler)(aperture)(Counter)


### PR DESCRIPTION
Good point made in [this discussion on Discord](https://discordapp.com/channels/102860784329052160/464102216601698314/491524763378909184) that it's a bit confusing to use non-existent variables in the example!

Added placeholders with a comment mentioning they'll be explained elsewhere, since each doc should aim to focus on one concept, with as little extra noise as possible.