### PR TITLE
Support apertures emitting elements

### DIFF
--- a/base/__tests__/inferno/callbag/index.tsx
+++ b/base/__tests__/inferno/callbag/index.tsx
@@ -1,3 +1,4 @@
+import { VNode } from 'inferno'
 import { createElement } from 'inferno-create-element'
 import {
     withEffects,
@@ -10,7 +11,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from '../../react/callbag/aperture'
 import { mount } from 'enzyme'
 
@@ -135,5 +137,24 @@ describe('refract-inferno-callbag', () => {
 
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<VNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+
+        const node = mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/__tests__/inferno/most/index.tsx
+++ b/base/__tests__/inferno/most/index.tsx
@@ -1,3 +1,4 @@
+import { VNode } from 'inferno'
 import { createElement } from 'inferno-create-element'
 import {
     withEffects,
@@ -10,7 +11,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from '../../react/most/aperture'
 import { mount } from 'enzyme'
 
@@ -135,5 +137,24 @@ describe('refract-inferno-most', () => {
 
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<VNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+
+        const node = mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/__tests__/inferno/rxjs/index.tsx
+++ b/base/__tests__/inferno/rxjs/index.tsx
@@ -1,3 +1,4 @@
+import { VNode } from 'inferno'
 import { createElement } from 'inferno-create-element'
 import {
     withEffects,
@@ -10,7 +11,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from '../../react/rxjs/aperture'
 import { mount } from 'enzyme'
 
@@ -135,5 +137,24 @@ describe('refract-inferno-rxjs', () => {
 
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<VNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+
+        const node = mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/__tests__/inferno/xstream/index.tsx
+++ b/base/__tests__/inferno/xstream/index.tsx
@@ -1,3 +1,4 @@
+import { VNode } from 'inferno'
 import { createElement } from 'inferno-create-element'
 import {
     withEffects,
@@ -10,7 +11,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from '../../react/xstream/aperture'
 import { mount } from 'enzyme'
 
@@ -135,5 +137,24 @@ describe('refract-inferno-xstream', () => {
 
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<VNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+
+        const node = mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -79,3 +79,12 @@ export const toPropsAperture: Aperture<
         })),
         map(toProps)
     )
+
+export const createRenderingAperture = <VNode>(
+    render: (prop: string) => VNode
+) => {
+    const aperture: Aperture<SourceProps, VNode> = () => component =>
+        pipe(component.observe('prop'), map(render))
+
+    return aperture
+}

--- a/base/__tests__/react/callbag/index.tsx
+++ b/base/__tests__/react/callbag/index.tsx
@@ -10,7 +10,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from './aperture'
 import { mount } from 'enzyme'
 
@@ -127,5 +128,23 @@ describe('refract-callbag', () => {
         const props = BaseComponent.mock.calls[0][0]
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<React.ReactNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
+            aperture
+        )()
+
+        const node = mount(<WithEffects prop="hello" />)
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -77,3 +77,12 @@ export const toPropsAperture: Aperture<
             newProp: `${prop} world`
         }))
         .map(toProps)
+
+export const createRenderingAperture = <VNode>(
+    render: (prop: string) => VNode
+) => {
+    const aperture: Aperture<SourceProps, VNode> = () => component =>
+        component.observe('prop').map(render)
+
+    return aperture
+}

--- a/base/__tests__/react/most/index.tsx
+++ b/base/__tests__/react/most/index.tsx
@@ -10,7 +10,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from './aperture'
 import { mount } from 'enzyme'
 
@@ -127,5 +128,23 @@ describe('refract-most', () => {
         const props = BaseComponent.mock.calls[0][0]
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<React.ReactNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
+            aperture
+        )()
+
+        const node = mount(<WithEffects prop="hello" />)
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -89,3 +89,12 @@ export const toPropsAperture: Aperture<
         })),
         map(toProps)
     )
+
+export const createRenderingAperture = <VNode>(
+    render: (prop: string) => VNode
+) => {
+    const aperture: Aperture<SourceProps, VNode> = () => component =>
+        component.observe('prop').pipe(map(render))
+
+    return aperture
+}

--- a/base/__tests__/react/rxjs/index.tsx
+++ b/base/__tests__/react/rxjs/index.tsx
@@ -10,7 +10,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from './aperture'
 import { mount } from 'enzyme'
 
@@ -126,5 +127,23 @@ describe('refract-rxjs', () => {
 
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<React.ReactNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
+            aperture
+        )()
+
+        const node = mount(<WithEffects prop="hello" />)
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -76,3 +76,12 @@ export const toPropsAperture: Aperture<
             newProp: `${prop} world`
         }))
         .map(toProps)
+
+export const createRenderingAperture = <VNode>(
+    render: (prop: string) => VNode
+) => {
+    const aperture: Aperture<SourceProps, VNode> = () => component =>
+        component.observe('prop').map(render)
+
+    return aperture
+}

--- a/base/__tests__/react/xstream/index.tsx
+++ b/base/__tests__/react/xstream/index.tsx
@@ -10,7 +10,8 @@ import {
     toPropsAperture,
     asPropsAperture,
     Effect,
-    Props
+    Props,
+    createRenderingAperture
 } from './aperture'
 import { mount } from 'enzyme'
 
@@ -127,5 +128,23 @@ describe('refract-xstream', () => {
         const props = BaseComponent.mock.calls[0][0]
         expect(props.prop).toBe('hello')
         expect(props.newProp).toBe('hello world')
+    })
+
+    it('should render virtual elements', () => {
+        const hander = () => () => void 0
+        interface Props {
+            prop: string
+        }
+        const aperture = createRenderingAperture<React.ReactNode>(prop => (
+            <div>{prop}</div>
+        ))
+        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
+            aperture
+        )()
+
+        const node = mount(<WithEffects prop="hello" />)
+
+        expect(node.text()).toBe('hello')
+        expect(node.find('div').exists()).toBe(true)
     })
 })

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -11,7 +11,11 @@ import {
 const configureComponent = <P, E>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
-) => (aperture: Aperture<P, E>, instance: any) => {
+) => (
+    aperture: Aperture<P, E>,
+    instance: any,
+    isValidElement?: (val: any) => boolean
+) => {
     instance.state = {
         children: null
     }
@@ -31,7 +35,11 @@ const configureComponent = <P, E>(
         const effectHandler = handler(initialProps)
 
         return effect => {
-            if (effect && effect.type === PROPS_EFFECT) {
+            if (isValidElement && isValidElement(effect)) {
+                setState({
+                    children: effect
+                })
+            } else if (effect && effect.type === PROPS_EFFECT) {
                 setState(effect.payload)
             } else {
                 effectHandler(effect)
@@ -132,7 +140,8 @@ const configureComponent = <P, E>(
         mount: mountObservable,
         unmount: unmountObservable,
         observe: createPropObservable,
-        event: createEventObservable
+        event: createEventObservable,
+        pushEvent
     }
 
     const sinkObservable = aperture(instance.props)(component)

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -1,4 +1,5 @@
 import { Observable, PartialObserver as Listener, Subscription } from 'rxjs'
+import { PushEvent } from './baseTypes'
 
 export { Listener, Subscription }
 
@@ -7,6 +8,7 @@ export interface ObservableComponent {
     event: <T>(eventName: string) => Observable<T>
     mount: Observable<any>
     unmount: Observable<any>
+    pushEvent: PushEvent
 }
 
 export type Aperture<P, E> = (

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -2,6 +2,7 @@ import $$observable from 'symbol-observable'
 import { Callbag, Source, Sink } from 'callbag'
 const fromObs = require('callbag-from-obs')
 const toObs = require('callbag-to-obs')
+import { PushEvent } from './baseTypes'
 
 export interface Listener<T> {
     next: (val: T) => void
@@ -18,6 +19,7 @@ export interface ObservableComponent {
     event: <T>(eventName: string) => Source<T>
     mount: Source<any>
     unmount: Source<any>
+    pushEvent: PushEvent
 }
 
 export type Aperture<P, E> = (

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -1,5 +1,6 @@
 import { from, Stream, Subscriber as Listener } from 'most'
 import $$observable from 'symbol-observable'
+import { PushEvent } from './baseTypes'
 
 export { Listener }
 
@@ -8,6 +9,7 @@ export interface ObservableComponent {
     event: <T>(eventName: string) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>
+    pushEvent: PushEvent
 }
 
 export interface Subscription {

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -1,4 +1,5 @@
 import xs, { Stream, Listener, Subscription } from 'xstream'
+import { PushEvent } from './baseTypes'
 
 export { Listener, Subscription }
 
@@ -7,6 +8,7 @@ export interface ObservableComponent {
     event: <T>(eventName: string) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>
+    pushEvent: PushEvent
 }
 
 export type Aperture<P, E> = (

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -6,6 +6,12 @@ import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 import { ReactElement } from 'react'
 
+export interface State {
+    replace?: boolean
+    props?: any
+    children: React.ReactNode | null
+}
+
 const Empty = () => null
 
 export const withEffects = <P, E, CP = P>(
@@ -14,10 +20,7 @@ export const withEffects = <P, E, CP = P>(
 ) => (aperture: Aperture<P, E>) => (
     BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): React.ComponentClass<P> =>
-    class WithEffects extends React.PureComponent<
-        P,
-        { children: ReactElement<any> | null }
-    > {
+    class WithEffects extends React.PureComponent<P, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
         private reDecorateProps: (nextProps: P) => void

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -12,7 +12,7 @@ export const withEffects = <P, E, CP = P>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
 ) => (aperture: Aperture<P, E>) => (
-    BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }>
+    BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): React.ComponentClass<P> =>
     class WithEffects extends React.PureComponent<
         P,

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -49,7 +49,6 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public componentDidUpdate(prevProps: P) {
-            this.unmounted = true
             this.pushProps(prevProps)
         }
 

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -1,10 +1,16 @@
-import { Component, ComponentType, ComponentClass } from 'inferno'
+import { Component, ComponentType, ComponentClass, VNode } from 'inferno'
 import { createElement } from 'inferno-create-element'
 
 import configureComponent from './configureComponent'
 
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
+
+export interface State {
+    replace?: boolean
+    props?: any
+    children: VNode | null
+}
 
 const Empty = () => null
 
@@ -22,7 +28,7 @@ export const withEffects = <P, E, CP = P>(
 ) => (aperture: Aperture<P, E>) => (
     BaseComponent: ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentClass<P> =>
-    class WithEffects extends Component<P> {
+    class WithEffects extends Component<P, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
         private reDecorateProps: (nextProps: P) => void
@@ -60,6 +66,10 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public render() {
+            if (this.state.children) {
+                return this.state.children
+            }
+
             return createElement(BaseComponent, this.getChildProps())
         }
     }

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -6,11 +6,21 @@ import configureComponent from './configureComponent'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 
+const Empty = () => null
+
+const isValidElement = (value: any): boolean =>
+    Boolean(value) &&
+    typeof value === 'object' &&
+    'children' in value &&
+    'childFlags' in value &&
+    'flags' in value &&
+    'parentVNode' in value
+
 export const withEffects = <P, E, CP = P>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
 ) => (aperture: Aperture<P, E>) => (
-    BaseComponent: ComponentType<CP & { pushEvent: PushEvent }>
+    BaseComponent: ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentClass<P> =>
     class WithEffects extends Component<P> {
         private triggerMount: () => void
@@ -24,7 +34,11 @@ export const withEffects = <P, E, CP = P>(
         constructor(props: any, context: any) {
             super(props, context)
 
-            configureComponent(handler, errorHandler)(aperture, this)
+            configureComponent(handler, errorHandler)(
+                aperture,
+                this,
+                isValidElement
+            )
         }
 
         public componentDidMount() {

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -1,9 +1,21 @@
-import { h, Component, ComponentFactory } from 'preact'
+import {
+    h,
+    Component,
+    ComponentFactory,
+    ComponentConstructor,
+    VNode
+} from 'preact'
 
 import configureComponent from './configureComponent'
 
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
+
+export interface State {
+    replace?: boolean
+    props?: any
+    children: VNode | null
+}
 
 const Empty = () => null
 
@@ -21,7 +33,7 @@ export const withEffects = <P, E, CP = P>(
 ) => (aperture: Aperture<P, E>) => (
     BaseComponent: ComponentFactory<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentFactory<P> =>
-    class WithEffects extends Component<P> {
+    class WithEffects extends Component<P, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
         private reDecorateProps: (nextProps: P) => void
@@ -59,6 +71,10 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public render() {
+            if (this.state.children) {
+                return this.state.children
+            }
+
             return h(BaseComponent, this.getChildProps())
         }
     }

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -5,11 +5,21 @@ import configureComponent from './configureComponent'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 
+const Empty = () => null
+
+const isValidElement = (value: any): boolean =>
+    Boolean(value) &&
+    typeof value === 'object' &&
+    'nodeName' in value &&
+    'children' in value &&
+    'attributes' in value &&
+    'key' in value
+
 export const withEffects = <P, E, CP = P>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
 ) => (aperture: Aperture<P, E>) => (
-    BaseComponent: ComponentFactory<CP & { pushEvent: PushEvent }>
+    BaseComponent: ComponentFactory<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentFactory<P> =>
     class WithEffects extends Component<P> {
         private triggerMount: () => void
@@ -23,7 +33,11 @@ export const withEffects = <P, E, CP = P>(
         constructor(props: P) {
             super(props)
 
-            configureComponent(handler, errorHandler)(aperture, this)
+            configureComponent(handler, errorHandler)(
+                aperture,
+                this,
+                isValidElement
+            )
         }
 
         public componentDidMount() {


### PR DESCRIPTION
Supporting rendering as a side-effect (for React components). This is very much a proof of concept, looking for feedback before rolling it out to other libs (Preact, Inferno). Code is untested (manually or with unit tests).

The `BaseComponent` becomes a placeholder while the first rendering value comes from the aperture (can be a loader, can be null). Under the hood, it uses `React.isValidElement` to handle it without impacting userland handlers.

```js
import { map, scan, startWith } from 'rxjs/operators'

const handler = initialProps => value => {}

const aperture = ({ initialValue }) => component =>
  component.event("click").pipe(
    scan(total => total + 1, initialValue),
    startWith(initialValue),
    map(total => (
      <div>
        Total: {total}
        <button onClick={component.pushValue("click")}>+ 1</button>
      </div>
    ))
  )

const Component = withEffects(handler)(aperture)()
```

Benefits of such an approach? state is the rendered node, which means local state can live in the aperture itself.