### PR TITLE
Support mapping data to props and replacing props

### DIFF
--- a/base/__tests__/inferno/callbag/index.tsx
+++ b/base/__tests__/inferno/callbag/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-inferno-callbag/src'
-import aperture, { Effect, Props } from '../../react/callbag/aperture'
+import { aperture, Effect, Props } from '../../react/callbag/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-callbag', () => {

--- a/base/__tests__/inferno/callbag/index.tsx
+++ b/base/__tests__/inferno/callbag/index.tsx
@@ -2,9 +2,16 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-inferno-callbag/src'
-import { aperture, Effect, Props } from '../../react/callbag/aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from '../../react/callbag/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-callbag', () => {
@@ -79,5 +86,54 @@ describe('refract-inferno-callbag', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/__tests__/inferno/most/index.tsx
+++ b/base/__tests__/inferno/most/index.tsx
@@ -2,9 +2,16 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-inferno-most/src'
-import { aperture, Effect, Props } from '../../react/most/aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from '../../react/most/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-most', () => {
@@ -79,5 +86,54 @@ describe('refract-inferno-most', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/__tests__/inferno/most/index.tsx
+++ b/base/__tests__/inferno/most/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-inferno-most/src'
-import aperture, { Effect, Props } from '../../react/most/aperture'
+import { aperture, Effect, Props } from '../../react/most/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-most', () => {

--- a/base/__tests__/inferno/rxjs/index.tsx
+++ b/base/__tests__/inferno/rxjs/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-inferno-rxjs/src'
-import aperture, { Effect, Props } from '../../react/rxjs/aperture'
+import { aperture, Effect, Props } from '../../react/rxjs/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-rxjs', () => {

--- a/base/__tests__/inferno/rxjs/index.tsx
+++ b/base/__tests__/inferno/rxjs/index.tsx
@@ -2,9 +2,16 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-inferno-rxjs/src'
-import { aperture, Effect, Props } from '../../react/rxjs/aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from '../../react/rxjs/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-rxjs', () => {
@@ -79,5 +86,54 @@ describe('refract-inferno-rxjs', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/__tests__/inferno/xstream/index.tsx
+++ b/base/__tests__/inferno/xstream/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-inferno-xstream/src'
-import aperture, { Effect, Props } from '../../react/xstream/aperture'
+import { aperture, Effect, Props } from '../../react/xstream/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-xstream', () => {

--- a/base/__tests__/inferno/xstream/index.tsx
+++ b/base/__tests__/inferno/xstream/index.tsx
@@ -2,9 +2,16 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-inferno-xstream/src'
-import { aperture, Effect, Props } from '../../react/xstream/aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from '../../react/xstream/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-inferno-xstream', () => {
@@ -79,5 +86,54 @@ describe('refract-inferno-xstream', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(
+            // @ts-ignore
+            <WithEffects prop="hello" />
+        )
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/__tests__/preact/callbag/index.tsx
+++ b/base/__tests__/preact/callbag/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-preact-callbag/src'
-import aperture, { Effect, Props } from '../../react/callbag/aperture'
+import { aperture, Effect, Props } from '../../react/callbag/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-preact-callbag', () => {

--- a/base/__tests__/preact/most/index.tsx
+++ b/base/__tests__/preact/most/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-preact-most/src'
-import aperture, { Effect, Props } from '../../react/most/aperture'
+import { aperture, Effect, Props } from '../../react/most/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-preact-most', () => {

--- a/base/__tests__/preact/rxjs/index.tsx
+++ b/base/__tests__/preact/rxjs/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-preact-rxjs/src'
-import aperture, { Effect, Props } from '../../react/rxjs/aperture'
+import { aperture, Effect, Props } from '../../react/rxjs/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-preact-rxjs', () => {

--- a/base/__tests__/preact/xstream/index.tsx
+++ b/base/__tests__/preact/xstream/index.tsx
@@ -4,7 +4,7 @@ import {
     Handler,
     ObservableComponent
 } from '../../../../packages/refract-preact-xstream/src'
-import aperture, { Effect, Props } from '../../react/xstream/aperture'
+import { aperture, Effect, Props } from '../../react/xstream/aperture'
 import { mount } from 'enzyme'
 
 describe('refract-preact-xstream', () => {

--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -1,6 +1,11 @@
-import { merge, map } from 'callbag-basics'
+import { merge, map, pipe } from 'callbag-basics'
 
-import { Aperture } from '../../../../packages/refract-callbag/src'
+import {
+    Aperture,
+    toProps,
+    asProps,
+    PropEffect
+} from '../../../../packages/refract-callbag/src'
 
 export interface Effect {
     type: string
@@ -12,7 +17,7 @@ export interface Props {
     setValue: (value: number) => void
 }
 
-const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -44,4 +49,33 @@ const aperture: Aperture<Props, Effect> = props => component => {
     )
 }
 
-export default aperture
+export interface SourceProps {
+    prop: string
+}
+interface SinkProps {
+    newProp: string
+}
+
+export const asPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    pipe(
+        component.observe(),
+        map(({ prop }) => ({
+            newProp: `${prop} world`
+        })),
+        map(asProps)
+    )
+
+export const toPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    pipe(
+        component.observe(),
+        map(({ prop }) => ({
+            newProp: `${prop} world`
+        })),
+        map(toProps)
+    )

--- a/base/__tests__/react/callbag/index.tsx
+++ b/base/__tests__/react/callbag/index.tsx
@@ -2,9 +2,16 @@ import * as React from 'react'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-callbag/src'
-import aperture, { Effect, Props } from './aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from './aperture'
 import { mount } from 'enzyme'
 
 describe('refract-callbag', () => {
@@ -78,5 +85,47 @@ describe('refract-callbag', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -1,6 +1,11 @@
 import { merge } from 'most'
 
-import { Aperture } from '../../../../packages/refract-most/src'
+import {
+    Aperture,
+    toProps,
+    asProps,
+    PropEffect
+} from '../../../../packages/refract-most/src'
 
 export interface Effect {
     type: string
@@ -12,7 +17,7 @@ export interface Props {
     setValue: (value: number) => void
 }
 
-const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -44,4 +49,31 @@ const aperture: Aperture<Props, Effect> = props => component => {
     )
 }
 
-export default aperture
+export interface SourceProps {
+    prop: string
+}
+interface SinkProps {
+    newProp: string
+}
+
+export const asPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    component
+        .observe()
+        .map(({ prop }) => ({
+            newProp: `${prop} world`
+        }))
+        .map(asProps)
+
+export const toPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    component
+        .observe()
+        .map(({ prop }) => ({
+            newProp: `${prop} world`
+        }))
+        .map(toProps)

--- a/base/__tests__/react/most/index.tsx
+++ b/base/__tests__/react/most/index.tsx
@@ -2,9 +2,16 @@ import * as React from 'react'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-most/src'
-import aperture, { Effect, Props } from './aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from './aperture'
 import { mount } from 'enzyme'
 
 describe('refract-most', () => {
@@ -78,5 +85,47 @@ describe('refract-most', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -1,11 +1,17 @@
-import { map, mapTo, concat } from 'rxjs/operators'
+import { map, mapTo } from 'rxjs/operators'
 import { merge } from 'rxjs'
 
-import { Aperture } from '../../../../packages/refract-rxjs/src'
+import {
+    Aperture,
+    toProps,
+    asProps,
+    PropEffect
+} from '../../../../packages/refract-rxjs/src'
 
 export interface Effect {
     type: string
     value?: number
+    payload?: object
 }
 
 export interface Props {
@@ -13,7 +19,7 @@ export interface Props {
     setValue: (value: number) => void
 }
 
-const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -55,4 +61,31 @@ const aperture: Aperture<Props, Effect> = props => component => {
     )
 }
 
-export default aperture
+export interface SourceProps {
+    prop: string
+}
+interface SinkProps {
+    newProp: string
+}
+
+export const asPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    component.observe().pipe(
+        map(({ prop }) => ({
+            newProp: `${prop} world`
+        })),
+        map(asProps)
+    )
+
+export const toPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    component.observe().pipe(
+        map(({ prop }) => ({
+            newProp: `${prop} world`
+        })),
+        map(toProps)
+    )

--- a/base/__tests__/react/rxjs/index.tsx
+++ b/base/__tests__/react/rxjs/index.tsx
@@ -2,9 +2,16 @@ import * as React from 'react'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-rxjs/src'
-import aperture, { Effect, Props } from './aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from './aperture'
 import { mount } from 'enzyme'
 
 describe('refract-rxjs', () => {
@@ -32,9 +39,7 @@ describe('refract-rxjs', () => {
             </div>
         ))
 
-        const component = mount(
-            React.createElement(WithEffects, { value: 1, setValue })
-        )
+        const component = mount(<WithEffects value={1} setValue={setValue} />)
 
         expect(component.prop('value')).toBe(1)
         expect(effectValueHandler).toHaveBeenCalledWith({
@@ -78,5 +83,48 @@ describe('refract-rxjs', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -1,5 +1,10 @@
 import xs from 'xstream'
-import { Aperture } from '../../../../packages/refract-xstream/src'
+import {
+    Aperture,
+    toProps,
+    asProps,
+    PropEffect
+} from '../../../../packages/refract-xstream/src'
 
 export interface Effect {
     type: string
@@ -11,7 +16,7 @@ export interface Props {
     setValue: (value: number) => void
 }
 
-const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -43,4 +48,31 @@ const aperture: Aperture<Props, Effect> = props => component => {
     )
 }
 
-export default aperture
+export interface SourceProps {
+    prop: string
+}
+interface SinkProps {
+    newProp: string
+}
+
+export const asPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    component
+        .observe()
+        .map(({ prop }) => ({
+            newProp: `${prop} world`
+        }))
+        .map(asProps)
+
+export const toPropsAperture: Aperture<
+    SourceProps,
+    PropEffect<SinkProps>
+> = () => component =>
+    component
+        .observe()
+        .map(({ prop }) => ({
+            newProp: `${prop} world`
+        }))
+        .map(toProps)

--- a/base/__tests__/react/xstream/index.tsx
+++ b/base/__tests__/react/xstream/index.tsx
@@ -2,9 +2,16 @@ import * as React from 'react'
 import {
     withEffects,
     Handler,
-    ObservableComponent
+    ObservableComponent,
+    PropEffect
 } from '../../../../packages/refract-xstream/src'
-import aperture, { Effect, Props } from './aperture'
+import {
+    aperture,
+    toPropsAperture,
+    asPropsAperture,
+    Effect,
+    Props
+} from './aperture'
 import { mount } from 'enzyme'
 
 describe('refract-xstream', () => {
@@ -78,5 +85,47 @@ describe('refract-xstream', () => {
         expect(effectValueHandler).toHaveBeenCalledWith({
             type: 'Stop'
         })
+    })
+
+    it('should map props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            asPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+
+        expect(props.prop).toBeUndefined()
+        expect(props.newProp).toBe('hello world')
+    })
+
+    it('should add props to wrapped component', () => {
+        interface Props {
+            prop: string
+        }
+        interface ChildProps {
+            prop: string
+            newProp: string
+        }
+        const BaseComponent = jest.fn().mockReturnValue(<div />)
+        const hander = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
+            toPropsAperture
+        )(BaseComponent)
+
+        mount(<WithEffects prop="hello" />)
+
+        const props = BaseComponent.mock.calls[0][0]
+        expect(props.prop).toBe('hello')
+        expect(props.newProp).toBe('hello world')
     })
 })

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -17,7 +17,7 @@ const configureComponent = <P, E>(
     }
 
     const setState = state => {
-        if (!instance.unmounted) {
+        if (instance.unmounted) {
             return
         }
         if (instance.mounted) {

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,0 +1,17 @@
+export const PROPS_EFFECT: string = '@@refract/effect/props'
+
+export const toProps = props => ({
+    type: PROPS_EFFECT,
+    payload: {
+        replace: false,
+        props
+    }
+})
+
+export const asProps = props => ({
+    type: PROPS_EFFECT,
+    payload: {
+        replace: true,
+        props
+    }
+})

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,6 +1,14 @@
 export const PROPS_EFFECT: string = '@@refract/effect/props'
 
-export const toProps = props => ({
+export interface PropEffect<P = object> {
+    type: string
+    payload: {
+        replace: boolean
+        props: P
+    }
+}
+
+export const toProps = <P>(props: P): PropEffect<P> => ({
     type: PROPS_EFFECT,
     payload: {
         replace: false,
@@ -8,7 +16,7 @@ export const toProps = props => ({
     }
 })
 
-export const asProps = props => ({
+export const asProps = <P>(props: P): PropEffect<P> => ({
     type: PROPS_EFFECT,
     payload: {
         replace: true,

--- a/base/react/index.ts
+++ b/base/react/index.ts
@@ -2,7 +2,7 @@ import { withEffects } from './withEffects'
 import { ObservableComponent, Aperture } from './observable'
 import { ErrorHandler, Handler } from './baseTypes'
 import { compose, Compose } from './compose'
-import { asProps, toProps, PROPS_EFFECT } from './effects'
+import { asProps, toProps, PROPS_EFFECT, PropEffect } from './effects'
 
 export {
     withEffects,
@@ -14,5 +14,6 @@ export {
     Compose,
     asProps,
     toProps,
+    PropEffect,
     PROPS_EFFECT
 }

--- a/base/react/index.ts
+++ b/base/react/index.ts
@@ -2,6 +2,7 @@ import { withEffects } from './withEffects'
 import { ObservableComponent, Aperture } from './observable'
 import { ErrorHandler, Handler } from './baseTypes'
 import { compose, Compose } from './compose'
+import { asProps, toProps, PROPS_EFFECT } from './effects'
 
 export {
     withEffects,
@@ -10,5 +11,8 @@ export {
     Handler,
     ErrorHandler,
     compose,
-    Compose
+    Compose,
+    asProps,
+    toProps,
+    PROPS_EFFECT
 }

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -14,7 +14,7 @@ export interface Subscription {
 }
 
 export interface ObservableComponent {
-    observe: <T = any>(propName: string) => Source<T>
+    observe: <T = any>(propName?: string) => Source<T>
     event: <T>(eventName: string) => Source<T>
     mount: Source<any>
     unmount: Source<any>

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -4,7 +4,7 @@ import $$observable from 'symbol-observable'
 export { Listener }
 
 export interface ObservableComponent {
-    observe: <T>(propName: string) => Stream<T>
+    observe: <T>(propName?: string) => Stream<T>
     event: <T>(eventName: string) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -3,7 +3,7 @@ import xs, { Stream, Listener, Subscription } from 'xstream'
 export { Listener, Subscription }
 
 export interface ObservableComponent {
-    observe: <T>(propName: string) => Stream<T>
+    observe: <T>(propName?: string) => Stream<T>
     event: <T>(eventName: string) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -41,10 +41,6 @@ export const withEffects = <P, E>(
         }
 
         public render() {
-            return React.createElement(
-                BaseComponent,
-                this.getChildProps(),
-                this.props.children
-            )
+            return React.createElement(BaseComponent, this.getChildProps())
         }
     }

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -5,18 +5,18 @@ import configureComponent from './configureComponent'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 
-export const withEffects = <P, E>(
+export const withEffects = <P, E, CP = P>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
 ) => (aperture: Aperture<P, E>) => (
-    BaseComponent: React.ComponentType<P & { pushEvent: PushEvent }>
+    BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }>
 ): React.ComponentClass<P> =>
     class WithEffects extends React.PureComponent<P> {
         private triggerMount: () => void
         private triggerUnmount: () => void
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
-        private getChildProps: () => P & { pushEvent: PushEvent }
+        private getChildProps: () => CP & { pushEvent: PushEvent }
 
         constructor(props: any, context: any) {
             super(props, context)

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -17,6 +17,8 @@ export const withEffects = <P, E, CP = P>(
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
         private getChildProps: () => CP & { pushEvent: PushEvent }
+        private mounted: boolean = false
+        private unmounted: boolean = false
 
         constructor(props: any, context: any) {
             super(props, context)
@@ -25,6 +27,7 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public componentDidMount() {
+            this.mounted = true
             this.triggerMount()
         }
 
@@ -37,6 +40,7 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public componentWillUnmount() {
+            this.unmounted = true
             this.triggerUnmount()
         }
 

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -6,18 +6,18 @@ import configureComponent from './configureComponent'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 
-export const withEffects = <P, E>(
+export const withEffects = <P, E, CP = P>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
 ) => (aperture: Aperture<P, E>) => (
-    BaseComponent: ComponentType<P & { pushEvent: PushEvent }>
+    BaseComponent: ComponentType<CP & { pushEvent: PushEvent }>
 ): ComponentClass<P> =>
     class WithEffects extends Component<P> {
         private triggerMount: () => void
         private triggerUnmount: () => void
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
-        private getChildProps: () => P & { pushEvent: PushEvent }
+        private getChildProps: () => CP & { pushEvent: PushEvent }
 
         constructor(props: any, context: any) {
             super(props, context)

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -18,6 +18,8 @@ export const withEffects = <P, E, CP = P>(
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
         private getChildProps: () => CP & { pushEvent: PushEvent }
+        private mounted: boolean = false
+        private unmounted: boolean = false
 
         constructor(props: any, context: any) {
             super(props, context)
@@ -26,6 +28,7 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public componentDidMount() {
+            this.mounted = true
             this.triggerMount()
         }
 
@@ -38,6 +41,7 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public componentWillUnmount() {
+            this.unmounted = true
             this.triggerUnmount()
         }
 

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -42,10 +42,6 @@ export const withEffects = <P, E>(
         }
 
         public render() {
-            return createElement(
-                BaseComponent,
-                this.getChildProps(),
-                this.props.children
-            )
+            return createElement(BaseComponent, this.getChildProps())
         }
     }

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -5,18 +5,18 @@ import configureComponent from './configureComponent'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 
-export const withEffects = <P, E>(
+export const withEffects = <P, E, CP = P>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
 ) => (aperture: Aperture<P, E>) => (
-    BaseComponent: ComponentFactory<P & { pushEvent: PushEvent }>
+    BaseComponent: ComponentFactory<CP & { pushEvent: PushEvent }>
 ): ComponentFactory<P> =>
     class WithEffects extends Component<P> {
         private triggerMount: () => void
         private triggerUnmount: () => void
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
-        private getChildProps: () => P & { pushEvent: PushEvent }
+        private getChildProps: () => CP & { pushEvent: PushEvent }
 
         constructor(props: P) {
             super(props)

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -41,6 +41,6 @@ export const withEffects = <P, E>(
         }
 
         public render() {
-            return h(BaseComponent, this.getChildProps(), this.props.children)
+            return h(BaseComponent, this.getChildProps())
         }
     }

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -17,6 +17,8 @@ export const withEffects = <P, E, CP = P>(
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
         private getChildProps: () => CP & { pushEvent: PushEvent }
+        private mounted: boolean = false
+        private unmounted: boolean = false
 
         constructor(props: P) {
             super(props)
@@ -25,6 +27,7 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public componentDidMount() {
+            this.mounted = true
             this.triggerMount()
         }
 
@@ -37,6 +40,7 @@ export const withEffects = <P, E, CP = P>(
         }
 
         public componentWillUnmount() {
+            this.unmounted = true
             this.triggerUnmount()
         }
 

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -11,6 +11,7 @@ const getPackages = require('../packages')
 const filesPerBaseDir = {
     react: [
         'baseTypes.ts',
+        'effects.ts',
         'index.ts',
         ({ mainLib }) => ({
             src: `withEffects${mainLib === 'react' ? '' : `_${mainLib}`}.ts`,


### PR DESCRIPTION
Can be used as a `withProps` or `mapProps` like in recompose:

**With props (add props)**

```js
import { withEffects, toProps } from 'refract'
import { map } from 'rxjs/operators'

const handler = initialProps => effect => {}

const aperture = () => component =>
    component
        .observe('value')
        .pipe(
            map(val => 2 * val),
            map(doubledVal => toProps({ doubledVal }))
        )

const Component = withEffects(handler)(aperture)(BaseComponent)
```

**Map props (replace props)**

```js
import { withEffects, asProps } from 'refract'
import { map } from 'rxjs/operators'

const handler = initialProps => effect => {}

const aperture = () => component =>
    component.observe().pipe(
        map(({ val, ...props }) => ({
            ...props,
            doubledVal: 2 * val
        })),
        map(asProps)
    )

const Component = withEffects(handler)(aperture)(BaseComponent)
```

**Handling state**

Props become state, a projection of events. No need for a state container, Refract acts as one.

```js
import { map, scan, startWith } from 'rxjs/operators'

const handler = initialProps => value => {}

const aperture = ({ initialValue }) => component =>
    component
        .event('click')
        .pipe(
            scan(total => total + 1, initialValue),
            startWith(initialValue),
            map(total => toProps({ total }))
        )

const Component = withEffects(handler)(aperture)(BaseComponent)
```

**As `connect`**

```js

import { withEffects, asProps } from 'refract'
import { merge } from 'rxjs'
import { map, mapTo } from 'rxjs/operators'

const handler = initialProps => effect => {}

const aperture = ({ store }) => component =>
    merge(
        store.observe(selectorA).pipe(map(a => ({ a }))),
        store.observe(selectorB).pipe(map(b => ({ b }))),
        store.observe(selectorC).pipe(map(c => ({ c })))
    ).pipe(mapTo(toProps))

const Component = withEffects(handler)(aperture)(BaseComponent)
```