### PR TITLE
Improve decoration of state props

### DIFF
--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -8,6 +8,11 @@ import {
     Aperture
 } from './observable'
 
+const shallowEquals = (left, right) =>
+    left === right ||
+    (Object.keys(left).length === Object.keys(right).length &&
+        Object.keys(left).every(leftKey => left[leftKey] === right[leftKey]))
+
 const configureComponent = <P, E>(
     handler: Handler<P, E>,
     errorHandler?: ErrorHandler<P>
@@ -238,6 +243,31 @@ const configureComponent = <P, E>(
         }
 
         return componentProps
+    }
+
+    instance.havePropsChanged = (newProps, newState) => {
+        const { state } = instance
+
+        if (state.children) {
+            return state.children !== newState.children
+        }
+
+        const haveStatePropsChanged = !shallowEquals(
+            state.props,
+            newState.props
+        )
+
+        if (newState.replace === true) {
+            return haveStatePropsChanged
+        }
+
+        const havePropsChanged = !shallowEquals(instance.props, newProps)
+
+        if (newState.replace === false) {
+            return havePropsChanged || haveStatePropsChanged
+        }
+
+        return havePropsChanged
     }
 }
 

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -17,7 +17,9 @@ const configureComponent = <P, E>(
     isValidElement?: (val: any) => boolean
 ) => {
     instance.state = {
-        children: null
+        children: null,
+        props: {},
+        decoratedProps: {}
     }
 
     const setState = state => {
@@ -41,29 +43,28 @@ const configureComponent = <P, E>(
                 })
             } else if (effect && effect.type === PROPS_EFFECT) {
                 const { payload } = effect
-                if (payload.replace) {
-                    setState({
-                        replace: payload.replace,
-                        props: Object.keys(payload.props || {}).reduce(
-                            (props, propName) => {
-                                const prop = payload.props[propName]
 
-                                if (
-                                    propName !== 'children' &&
-                                    typeof prop === 'function'
-                                ) {
-                                    decorateProp(props, prop, propName)
-                                } else {
-                                    props[propName] = prop
-                                }
-                                return props
-                            },
-                            {}
-                        )
-                    })
-                } else {
-                    setState(payload)
-                }
+                setState({
+                    replace: payload.replace,
+                    props: payload.props,
+                    decoratedProps: Object.keys(payload.props || {}).reduce(
+                        (props, propName) => {
+                            const prop = payload.props[propName]
+                            const previousProp = instance.state.props[propName]
+
+                            if (
+                                propName !== 'children' &&
+                                typeof prop === 'function' &&
+                                prop !== previousProp
+                            ) {
+                                decorateProp(props, prop, propName)
+                            }
+
+                            return props
+                        },
+                        {}
+                    )
+                })
             } else {
                 effectHandler(effect)
             }
@@ -190,6 +191,7 @@ const configureComponent = <P, E>(
     instance.reDecorateProps = nextProps => {
         Object.keys(nextProps).forEach(propName => {
             if (
+                propName !== 'children' &&
                 typeof instance.props[propName] === 'function' &&
                 nextProps[propName] !== instance.props[propName]
             ) {
@@ -212,21 +214,30 @@ const configureComponent = <P, E>(
     }
 
     instance.getChildProps = () => {
-        const { props = {}, replace } = instance.state
-
-        if (replace === true) {
-            return Object.assign({}, props, {
-                pushEvent
-            })
-        } else if (replace === false) {
-            return Object.assign({}, instance.props, decoratedProps, props, {
-                pushEvent
-            })
+        const { state } = instance
+        const stateProps = {
+            ...state.props,
+            ...state.decoratedProps
         }
 
-        return Object.assign({}, instance.props, decoratedProps, {
+        if (state.replace === true) {
+            return { ...stateProps, pushEvent }
+        }
+
+        const componentProps = {
+            ...instance.props,
+            ...(decoratedProps as object),
             pushEvent
-        })
+        }
+
+        if (state.replace === false) {
+            return {
+                ...componentProps,
+                ...stateProps
+            }
+        }
+
+        return componentProps
     }
 }
 

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -8,7 +8,8 @@ import { ReactElement } from 'react'
 
 export interface State {
     replace?: boolean
-    props?: any
+    props: object
+    decoratedProps: object
     children: React.ReactNode | null
 }
 

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -21,9 +21,10 @@ export const withEffects = <P, E, CP = P>(
 ) => (aperture: Aperture<P, E>) => (
     BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): React.ComponentClass<P> =>
-    class WithEffects extends React.PureComponent<P, State> {
+    class WithEffects extends React.Component<P, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
+        private havePropsChanged: (nextProps: P, nextState: State) => boolean
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
         private getChildProps: () => CP & { pushEvent: PushEvent }
@@ -47,6 +48,10 @@ export const withEffects = <P, E, CP = P>(
 
         public componentWillReceiveProps(nextProps: P) {
             this.reDecorateProps(nextProps)
+        }
+
+        public shouldComponentUpdate(nextProps, nextState) {
+            return this.havePropsChanged(nextProps, nextState)
         }
 
         public componentDidUpdate(prevProps: P) {

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -8,7 +8,8 @@ import { Aperture } from './observable'
 
 export interface State {
     replace?: boolean
-    props?: any
+    props: object
+    decoratedProps: object
     children: VNode | null
 }
 

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -32,6 +32,7 @@ export const withEffects = <P, E, CP = P>(
     class WithEffects extends Component<P, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
+        private havePropsChanged: (nextProps: P, nextState: State) => boolean
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
         private getChildProps: () => CP & { pushEvent: PushEvent }
@@ -55,6 +56,10 @@ export const withEffects = <P, E, CP = P>(
 
         public componentWillUpdate(nextProps: P) {
             this.reDecorateProps(nextProps)
+        }
+
+        public shouldComponentUpdate(nextProps, nextState) {
+            return this.havePropsChanged(nextProps, nextState)
         }
 
         public componentDidUpdate(lastProps: P) {

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -6,6 +6,7 @@ import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 
 export interface State {
+    replace?: boolean
     props: object
     decoratedProps: object
     children: VNode | null
@@ -30,6 +31,7 @@ export const withEffects = <P, E, CP = P>(
     class WithEffects extends Component<P, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
+        private havePropsChanged: (nextProps: P, nextState: State) => boolean
         private reDecorateProps: (nextProps: P) => void
         private pushProps: (props: P) => void
         private getChildProps: () => CP & { pushEvent: PushEvent }
@@ -53,6 +55,10 @@ export const withEffects = <P, E, CP = P>(
 
         public componentWillReceiveProps(nextProps) {
             this.reDecorateProps(nextProps)
+        }
+
+        public shouldComponentUpdate(nextProps, nextState) {
+            return this.havePropsChanged(nextProps, nextState)
         }
 
         public componentDidUpdate(prevProps: P) {

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -1,10 +1,4 @@
-import {
-    h,
-    Component,
-    ComponentFactory,
-    ComponentConstructor,
-    VNode
-} from 'preact'
+import { h, Component, ComponentFactory, VNode } from 'preact'
 
 import configureComponent from './configureComponent'
 
@@ -12,8 +6,8 @@ import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { Aperture } from './observable'
 
 export interface State {
-    replace?: boolean
-    props?: any
+    props: object
+    decoratedProps: object
     children: VNode | null
 }
 


### PR DESCRIPTION
- Props decorated whether they replace or not existing props (not sure why I just considered the "replace" case)
- Store state decorated props separately from state props, so they can be compared and are only decorated if changed (consistent with component props)
- As a result, `shouldComponentUpdate` can be implemented, and we avoid unnecessary re-renders