### PR TITLE
Rename event method to fromEvent

### DIFF
--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -22,7 +22,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return merge(
         map(value => ({

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -22,7 +22,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return merge<Effect>(
         value$.map(value => ({

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -24,7 +24,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return merge<Effect>(
         value$.pipe(

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -21,7 +21,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return xs.merge<Effect>(
         value$.map(value => ({

--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -10,7 +10,7 @@ export interface Listeners {
     allProps: Array<Partial<Listener<any>>>
     props: KeyedListeners
     fnProps: KeyedListeners
-    event: KeyedListeners
+    fromEvent: KeyedListeners
 }
 
 export type Handler<P, E> = (intialProps: P) => (val: E) => void

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -82,11 +82,11 @@ const configureComponent = <P, E>(
         allProps: [],
         props: {},
         fnProps: {},
-        event: {}
+        fromEvent: {}
     }
     const decoratedProps: Partial<P> = {}
     const pushEvent: PushEvent = (eventName: string) => <T>(val: T) => {
-        ;(listeners.event[eventName] || []).forEach(listener =>
+        ;(listeners.fromEvent[eventName] || []).forEach(listener =>
             listener.next(val)
         )
     }
@@ -155,12 +155,12 @@ const configureComponent = <P, E>(
 
     const createEventObservable = <T>(eventName: string) => {
         return createObservable<T>(listener => {
-            listeners.event[eventName] = (
-                listeners.event[eventName] || []
+            listeners.fromEvent[eventName] = (
+                listeners.fromEvent[eventName] || []
             ).concat(listener)
 
             return () => {
-                listeners.event[eventName].filter(l => l !== listener)
+                listeners.fromEvent[eventName].filter(l => l !== listener)
             }
         })
     }
@@ -169,7 +169,7 @@ const configureComponent = <P, E>(
         mount: mountObservable,
         unmount: unmountObservable,
         observe: createPropObservable,
-        event: createEventObservable,
+        fromEvent: createEventObservable,
         pushEvent
     }
 

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -5,7 +5,7 @@ export { Listener, Subscription }
 
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Observable<T>
-    event: <T>(eventName: string) => Observable<T>
+    fromEvent: <T>(eventName: string) => Observable<T>
     mount: Observable<any>
     unmount: Observable<any>
     pushEvent: PushEvent

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -16,7 +16,7 @@ export interface Subscription {
 
 export interface ObservableComponent {
     observe: <T = any>(propName?: string) => Source<T>
-    event: <T>(eventName: string) => Source<T>
+    fromEvent: <T>(eventName: string) => Source<T>
     mount: Source<any>
     unmount: Source<any>
     pushEvent: PushEvent

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -6,7 +6,7 @@ export { Listener }
 
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
-    event: <T>(eventName: string) => Stream<T>
+    fromEvent: <T>(eventName: string) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>
     pushEvent: PushEvent

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -5,7 +5,7 @@ export { Listener, Subscription }
 
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
-    event: <T>(eventName: string) => Stream<T>
+    fromEvent: <T>(eventName: string) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>
     pushEvent: PushEvent

--- a/docs/usage/observing-react.md
+++ b/docs/usage/observing-react.md
@@ -126,11 +126,11 @@ function MyComponent({ pushEvent }) {
 
 ### Observing events
 
-In your aperture, you can observe events by simply invoking `component.event(eventName)`.
+In your aperture, you can observe events by simply invoking `component.fromEvent(eventName)`.
 
 ```js
 const aperture = initialProps => component => {
-    const buttonClick$ = component.event('buttonClick')
+    const buttonClick$ = component.fromEvent('buttonClick')
 
     return buttonClick$.pipe(mapTo('Button clicked!'))
 }


### PR DESCRIPTION
Plain `component.event` doesn't quite read right - `component.fromEvent` is clearer and more in line with other APIs (such as `rxjs.fromEvent(document, 'scroll')`, so worth making the change!