### PR TITLE
Remove mount and unmount methods

### DIFF
--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -20,8 +20,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.event('mount')
+    const unmount$ = component.event('unmount')
     const linkClick$ = component.event<any>('linkClick')
 
     return merge(

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -20,8 +20,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.event('mount')
+    const unmount$ = component.event('unmount')
     const linkClick$ = component.event<any>('linkClick')
 
     return merge<Effect>(

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -22,8 +22,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.event('mount')
+    const unmount$ = component.event('unmount')
     const linkClick$ = component.event<any>('linkClick')
 
     return merge<Effect>(

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -19,8 +19,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.event('mount')
+    const unmount$ = component.event('unmount')
     const linkClick$ = component.event<any>('linkClick')
 
     return xs.merge<Effect>(

--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -5,8 +5,6 @@ export interface KeyedListeners {
 }
 
 export interface Listeners {
-    mount: Array<Partial<Listener<any>>>
-    unmount: Array<Partial<Listener<any>>>
     allProps: Array<Partial<Listener<any>>>
     props: KeyedListeners
     fnProps: KeyedListeners

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -77,8 +77,6 @@ const configureComponent = <P, E>(
     }
 
     const listeners: Listeners = {
-        mount: [],
-        unmount: [],
         allProps: [],
         props: {},
         fnProps: {},
@@ -107,18 +105,6 @@ const configureComponent = <P, E>(
         if (typeof instance.props[propName] === 'function') {
             decorateProp(decoratedProps, instance.props[propName], propName)
         }
-    })
-
-    const mountObservable = createObservable<any>(listener => {
-        listeners.mount = listeners.mount.concat(listener)
-
-        return () => listeners.mount.filter(l => l !== listener)
-    })
-
-    const unmountObservable = createObservable<any>(listener => {
-        listeners.unmount = listeners.unmount.concat(listener)
-
-        return () => listeners.unmount.filter(l => l !== listener)
     })
 
     const createPropObservable = <T>(propName?: string) => {
@@ -166,8 +152,6 @@ const configureComponent = <P, E>(
     }
 
     const component: ObservableComponent = {
-        mount: mountObservable,
-        unmount: unmountObservable,
         observe: createPropObservable,
         event: createEventObservable,
         pushEvent
@@ -209,11 +193,11 @@ const configureComponent = <P, E>(
     }
 
     instance.triggerMount = () => {
-        listeners.mount.forEach(l => l.next(undefined))
+        pushEvent('mount')(undefined)
     }
 
     instance.triggerUnmount = () => {
-        listeners.unmount.forEach(l => l.next(undefined))
+        pushEvent('unmount')(undefined)
         sinkSubscription.unsubscribe()
     }
 

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -6,8 +6,6 @@ export { Listener, Subscription }
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Observable<T>
     event: <T>(eventName: string) => Observable<T>
-    mount: Observable<any>
-    unmount: Observable<any>
     pushEvent: PushEvent
 }
 

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -17,8 +17,6 @@ export interface Subscription {
 export interface ObservableComponent {
     observe: <T = any>(propName?: string) => Source<T>
     event: <T>(eventName: string) => Source<T>
-    mount: Source<any>
-    unmount: Source<any>
     pushEvent: PushEvent
 }
 

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -7,8 +7,6 @@ export { Listener }
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
     event: <T>(eventName: string) => Stream<T>
-    mount: Stream<any>
-    unmount: Stream<any>
     pushEvent: PushEvent
 }
 

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -6,8 +6,6 @@ export { Listener, Subscription }
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
     event: <T>(eventName: string) => Stream<T>
-    mount: Stream<any>
-    unmount: Stream<any>
     pushEvent: PushEvent
 }
 


### PR DESCRIPTION
Both `component.mount` and `component.unmount` can easily be folded into the `component.event` (or `component.fromEvent`) concept, which reduces the API surface and adds some more consistency! 🎉