### PR TITLE
Use fromEvent internally for mount and unmount

### DIFF
--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -5,8 +5,6 @@ export interface KeyedListeners {
 }
 
 export interface Listeners {
-    mount: Array<Partial<Listener<any>>>
-    unmount: Array<Partial<Listener<any>>>
     allProps: Array<Partial<Listener<any>>>
     props: KeyedListeners
     fnProps: KeyedListeners

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,5 +1,5 @@
 import { Listeners, Handler, ErrorHandler, PushEvent } from './baseTypes'
-import { PROPS_EFFECT, MOUNT_EFFECT, UNMOUNT_EFFECT } from './effects'
+import { PROPS_EFFECT } from './effects'
 import {
     Subscription,
     createObservable,
@@ -7,6 +7,9 @@ import {
     subscribeToSink,
     Aperture
 } from './observable'
+
+const MOUNT_EVENT: string = '@@refract/event/mount'
+const UNMOUNT_EVENT: string = '@@refract/event/unmount'
 
 const shallowEquals = (left, right) =>
     left === right ||
@@ -152,8 +155,8 @@ const configureComponent = <P, E>(
     }
 
     const component: ObservableComponent = {
-        mount: createEventObservable(MOUNT_EFFECT),
-        unmount: createEventObservable(UNMOUNT_EFFECT),
+        mount: createEventObservable(MOUNT_EVENT),
+        unmount: createEventObservable(UNMOUNT_EVENT),
         observe: createPropObservable,
         event: createEventObservable,
         pushEvent
@@ -195,11 +198,11 @@ const configureComponent = <P, E>(
     }
 
     instance.triggerMount = () => {
-        pushEvent(MOUNT_EFFECT)(undefined)
+        pushEvent(MOUNT_EVENT)(undefined)
     }
 
     instance.triggerUnmount = () => {
-        pushEvent(UNMOUNT_EFFECT)(undefined)
+        pushEvent(UNMOUNT_EVENT)(undefined)
         sinkSubscription.unsubscribe()
     }
 

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,5 +1,5 @@
 import { Listeners, Handler, ErrorHandler, PushEvent } from './baseTypes'
-import { PROPS_EFFECT } from './effects'
+import { PROPS_EFFECT, MOUNT_EFFECT, UNMOUNT_EFFECT } from './effects'
 import {
     Subscription,
     createObservable,
@@ -77,8 +77,6 @@ const configureComponent = <P, E>(
     }
 
     const listeners: Listeners = {
-        mount: [],
-        unmount: [],
         allProps: [],
         props: {},
         fnProps: {},
@@ -107,18 +105,6 @@ const configureComponent = <P, E>(
         if (typeof instance.props[propName] === 'function') {
             decorateProp(decoratedProps, instance.props[propName], propName)
         }
-    })
-
-    const mountObservable = createObservable<any>(listener => {
-        listeners.mount = listeners.mount.concat(listener)
-
-        return () => listeners.mount.filter(l => l !== listener)
-    })
-
-    const unmountObservable = createObservable<any>(listener => {
-        listeners.unmount = listeners.unmount.concat(listener)
-
-        return () => listeners.unmount.filter(l => l !== listener)
     })
 
     const createPropObservable = <T>(propName?: string) => {
@@ -166,8 +152,8 @@ const configureComponent = <P, E>(
     }
 
     const component: ObservableComponent = {
-        mount: mountObservable,
-        unmount: unmountObservable,
+        mount: createEventObservable(MOUNT_EFFECT),
+        unmount: createEventObservable(UNMOUNT_EFFECT),
         observe: createPropObservable,
         event: createEventObservable,
         pushEvent
@@ -209,11 +195,11 @@ const configureComponent = <P, E>(
     }
 
     instance.triggerMount = () => {
-        listeners.mount.forEach(l => l.next(undefined))
+        pushEvent(MOUNT_EFFECT)(undefined)
     }
 
     instance.triggerUnmount = () => {
-        listeners.unmount.forEach(l => l.next(undefined))
+        pushEvent(UNMOUNT_EFFECT)(undefined)
         sinkSubscription.unsubscribe()
     }
 

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,4 +1,6 @@
 export const PROPS_EFFECT: string = '@@refract/effect/props'
+export const MOUNT_EFFECT: string = '@@refract/effect/mount'
+export const UNMOUNT_EFFECT: string = '@@refract/effect/unmount'
 
 export interface PropEffect<P = object> {
     type: string

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,6 +1,4 @@
 export const PROPS_EFFECT: string = '@@refract/effect/props'
-export const MOUNT_EFFECT: string = '@@refract/effect/mount'
-export const UNMOUNT_EFFECT: string = '@@refract/effect/unmount'
 
 export interface PropEffect<P = object> {
     type: string


### PR DESCRIPTION
Good point from @troch re: #89 that it's arguably leaking an implementation detail, and would introduce edge cases like a user calling `pushEvent('mount')`; instead we can use `fromEvent` internally to reduce code complexity while keeping the same API. 🙂 