### PR TITLE
V2/breaking changes

### DIFF
--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -20,8 +20,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.mount$
+    const unmount$ = component.unmount$
     const linkClick$ = component.event<any>('linkClick')
 
     return merge(

--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -22,7 +22,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount$
     const unmount$ = component.unmount$
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return merge(
         map(value => ({

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -22,7 +22,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount$
     const unmount$ = component.unmount$
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return merge<Effect>(
         value$.map(value => ({

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -20,8 +20,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.mount$
+    const unmount$ = component.unmount$
     const linkClick$ = component.event<any>('linkClick')
 
     return merge<Effect>(

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -24,7 +24,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount$
     const unmount$ = component.unmount$
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return merge<Effect>(
         value$.pipe(

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -22,8 +22,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.mount$
+    const unmount$ = component.unmount$
     const linkClick$ = component.event<any>('linkClick')
 
     return merge<Effect>(

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -21,7 +21,7 @@ export const aperture: Aperture<Props, Effect> = props => component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount$
     const unmount$ = component.unmount$
-    const linkClick$ = component.event<any>('linkClick')
+    const linkClick$ = component.fromEvent<any>('linkClick')
 
     return xs.merge<Effect>(
         value$.map(value => ({

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -19,8 +19,8 @@ export interface Props {
 export const aperture: Aperture<Props, Effect> = props => component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
-    const mount$ = component.mount
-    const unmount$ = component.unmount
+    const mount$ = component.mount$
+    const unmount$ = component.unmount$
     const linkClick$ = component.event<any>('linkClick')
 
     return xs.merge<Effect>(

--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -5,8 +5,6 @@ export interface KeyedListeners {
 }
 
 export interface Listeners {
-    mount: Array<Partial<Listener<any>>>
-    unmount: Array<Partial<Listener<any>>>
     allProps: Array<Partial<Listener<any>>>
     props: KeyedListeners
     fnProps: KeyedListeners

--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -8,7 +8,7 @@ export interface Listeners {
     allProps: Array<Partial<Listener<any>>>
     props: KeyedListeners
     fnProps: KeyedListeners
-    event: KeyedListeners
+    fromEvent: KeyedListeners
 }
 
 export type Handler<P, E> = (intialProps: P) => (val: E) => void

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,5 +1,5 @@
 import { Listeners, Handler, ErrorHandler, PushEvent } from './baseTypes'
-import { PROPS_EFFECT, MOUNT_EFFECT, UNMOUNT_EFFECT } from './effects'
+import { PROPS_EFFECT } from './effects'
 import {
     Subscription,
     createObservable,
@@ -7,6 +7,9 @@ import {
     subscribeToSink,
     Aperture
 } from './observable'
+
+const MOUNT_EVENT: string = '@@refract/event/mount'
+const UNMOUNT_EVENT: string = '@@refract/event/unmount'
 
 const shallowEquals = (left, right) =>
     left === right ||
@@ -152,8 +155,8 @@ const configureComponent = <P, E>(
     }
 
     const component: ObservableComponent = {
-        mount: createEventObservable(MOUNT_EFFECT),
-        unmount: createEventObservable(UNMOUNT_EFFECT),
+        mount: createEventObservable(MOUNT_EVENT),
+        unmount: createEventObservable(UNMOUNT_EVENT),
         observe: createPropObservable,
         event: createEventObservable,
         pushEvent
@@ -195,11 +198,11 @@ const configureComponent = <P, E>(
     }
 
     instance.triggerMount = () => {
-        pushEvent(MOUNT_EFFECT)(undefined)
+        pushEvent(MOUNT_EVENT)(undefined)
     }
 
     instance.triggerUnmount = () => {
-        pushEvent(UNMOUNT_EFFECT)(undefined)
+        pushEvent(UNMOUNT_EVENT)(undefined)
         sinkSubscription.unsubscribe()
     }
 

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,5 +1,5 @@
 import { Listeners, Handler, ErrorHandler, PushEvent } from './baseTypes'
-import { PROPS_EFFECT } from './effects'
+import { PROPS_EFFECT, MOUNT_EFFECT, UNMOUNT_EFFECT } from './effects'
 import {
     Subscription,
     createObservable,
@@ -77,8 +77,6 @@ const configureComponent = <P, E>(
     }
 
     const listeners: Listeners = {
-        mount: [],
-        unmount: [],
         allProps: [],
         props: {},
         fnProps: {},
@@ -107,18 +105,6 @@ const configureComponent = <P, E>(
         if (typeof instance.props[propName] === 'function') {
             decorateProp(decoratedProps, instance.props[propName], propName)
         }
-    })
-
-    const mountObservable = createObservable<any>(listener => {
-        listeners.mount = listeners.mount.concat(listener)
-
-        return () => listeners.mount.filter(l => l !== listener)
-    })
-
-    const unmountObservable = createObservable<any>(listener => {
-        listeners.unmount = listeners.unmount.concat(listener)
-
-        return () => listeners.unmount.filter(l => l !== listener)
     })
 
     const createPropObservable = <T>(propName?: string) => {
@@ -166,8 +152,8 @@ const configureComponent = <P, E>(
     }
 
     const component: ObservableComponent = {
-        mount: mountObservable,
-        unmount: unmountObservable,
+        mount: createEventObservable(MOUNT_EFFECT),
+        unmount: createEventObservable(UNMOUNT_EFFECT),
         observe: createPropObservable,
         event: createEventObservable,
         pushEvent
@@ -209,11 +195,11 @@ const configureComponent = <P, E>(
     }
 
     instance.triggerMount = () => {
-        listeners.mount.forEach(l => l.next(undefined))
+        pushEvent(MOUNT_EFFECT)(undefined)
     }
 
     instance.triggerUnmount = () => {
-        listeners.unmount.forEach(l => l.next(undefined))
+        pushEvent(UNMOUNT_EFFECT)(undefined)
         sinkSubscription.unsubscribe()
     }
 

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -155,8 +155,8 @@ const configureComponent = <P, E>(
     }
 
     const component: ObservableComponent = {
-        mount: createEventObservable(MOUNT_EVENT),
-        unmount: createEventObservable(UNMOUNT_EVENT),
+        mount$: createEventObservable(MOUNT_EVENT),
+        unmount$: createEventObservable(UNMOUNT_EVENT),
         observe: createPropObservable,
         event: createEventObservable,
         pushEvent

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -83,11 +83,11 @@ const configureComponent = <P, E>(
         allProps: [],
         props: {},
         fnProps: {},
-        event: {}
+        fromEvent: {}
     }
     const decoratedProps: Partial<P> = {}
     const pushEvent: PushEvent = (eventName: string) => <T>(val: T) => {
-        ;(listeners.event[eventName] || []).forEach(listener =>
+        ;(listeners.fromEvent[eventName] || []).forEach(listener =>
             listener.next(val)
         )
     }
@@ -144,12 +144,12 @@ const configureComponent = <P, E>(
 
     const createEventObservable = <T>(eventName: string) => {
         return createObservable<T>(listener => {
-            listeners.event[eventName] = (
-                listeners.event[eventName] || []
+            listeners.fromEvent[eventName] = (
+                listeners.fromEvent[eventName] || []
             ).concat(listener)
 
             return () => {
-                listeners.event[eventName].filter(l => l !== listener)
+                listeners.fromEvent[eventName].filter(l => l !== listener)
             }
         })
     }
@@ -158,7 +158,7 @@ const configureComponent = <P, E>(
         mount$: createEventObservable(MOUNT_EVENT),
         unmount$: createEventObservable(UNMOUNT_EVENT),
         observe: createPropObservable,
-        event: createEventObservable,
+        fromEvent: createEventObservable,
         pushEvent
     }
 

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,4 +1,6 @@
 export const PROPS_EFFECT: string = '@@refract/effect/props'
+export const MOUNT_EFFECT: string = '@@refract/effect/mount'
+export const UNMOUNT_EFFECT: string = '@@refract/effect/unmount'
 
 export interface PropEffect<P = object> {
     type: string

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,6 +1,4 @@
 export const PROPS_EFFECT: string = '@@refract/effect/props'
-export const MOUNT_EFFECT: string = '@@refract/effect/mount'
-export const UNMOUNT_EFFECT: string = '@@refract/effect/unmount'
 
 export interface PropEffect<P = object> {
     type: string

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -6,8 +6,8 @@ export { Listener, Subscription }
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Observable<T>
     event: <T>(eventName: string) => Observable<T>
-    mount: Observable<any>
-    unmount: Observable<any>
+    mount$: Observable<any>
+    unmount$: Observable<any>
     pushEvent: PushEvent
 }
 

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -5,7 +5,7 @@ export { Listener, Subscription }
 
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Observable<T>
-    event: <T>(eventName: string) => Observable<T>
+    fromEvent: <T>(eventName: string) => Observable<T>
     mount$: Observable<any>
     unmount$: Observable<any>
     pushEvent: PushEvent

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -16,7 +16,7 @@ export interface Subscription {
 
 export interface ObservableComponent {
     observe: <T = any>(propName?: string) => Source<T>
-    event: <T>(eventName: string) => Source<T>
+    fromEvent: <T>(eventName: string) => Source<T>
     mount$: Source<any>
     unmount$: Source<any>
     pushEvent: PushEvent

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -17,8 +17,8 @@ export interface Subscription {
 export interface ObservableComponent {
     observe: <T = any>(propName?: string) => Source<T>
     event: <T>(eventName: string) => Source<T>
-    mount: Source<any>
-    unmount: Source<any>
+    mount$: Source<any>
+    unmount$: Source<any>
     pushEvent: PushEvent
 }
 

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -7,8 +7,8 @@ export { Listener }
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
     event: <T>(eventName: string) => Stream<T>
-    mount: Stream<any>
-    unmount: Stream<any>
+    mount$: Stream<any>
+    unmount$: Stream<any>
     pushEvent: PushEvent
 }
 

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -6,7 +6,7 @@ export { Listener }
 
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
-    event: <T>(eventName: string) => Stream<T>
+    fromEvent: <T>(eventName: string) => Stream<T>
     mount$: Stream<any>
     unmount$: Stream<any>
     pushEvent: PushEvent

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -5,7 +5,7 @@ export { Listener, Subscription }
 
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
-    event: <T>(eventName: string) => Stream<T>
+    fromEvent: <T>(eventName: string) => Stream<T>
     mount$: Stream<any>
     unmount$: Stream<any>
     pushEvent: PushEvent

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -6,8 +6,8 @@ export { Listener, Subscription }
 export interface ObservableComponent {
     observe: <T>(propName?: string) => Stream<T>
     event: <T>(eventName: string) => Stream<T>
-    mount: Stream<any>
-    unmount: Stream<any>
+    mount$: Stream<any>
+    unmount$: Stream<any>
     pushEvent: PushEvent
 }
 

--- a/docs/usage/observing-react.md
+++ b/docs/usage/observing-react.md
@@ -126,11 +126,11 @@ function MyComponent({ pushEvent }) {
 
 ### Observing events
 
-In your aperture, you can observe events by simply invoking `component.event(eventName)`.
+In your aperture, you can observe events by simply invoking `component.fromEvent(eventName)`.
 
 ```js
 const aperture = initialProps => component => {
-    const buttonClick$ = component.event('buttonClick')
+    const buttonClick$ = component.fromEvent('buttonClick')
 
     return buttonClick$.pipe(mapTo('Button clicked!'))
 }

--- a/docs/usage/observing-react.md
+++ b/docs/usage/observing-react.md
@@ -10,7 +10,7 @@ const aperture = initialProps => component => {
 }
 ```
 
-This `component` object contains three properties: `observe`, `mount`, and `unmount`. The `observe` property is a function which let you observe your React props. The `mount` and `unmount` properties are streams which let you observe your React component's lifecycle.
+This `component` object contains three properties: `observe`, `mount$`, and `unmount$`. The `observe` property is a function which let you observe your React props. The `mount$` and `unmount$` properties are streams which let you observe your React component's lifecycle.
 
 ## Example
 
@@ -138,19 +138,19 @@ const aperture = initialProps => component => {
 
 ## Observing Lifecycle Events
 
-The remaining two properties on the `component` object are `component.mount` and `component.unmount`.
+The remaining two properties on the `component` object are `component.mount$` and `component.unmount$`.
 
 These are streams which emit an event, like a signal, either when the component mounts or when the component unmounts.
 
 ### Observing Component Mount
 
-`component.mount` is a stream which will emit a single value when a component mounts.
+`component.mount$` is a stream which will emit a single value when a component mounts.
 
 It can be useful to defer any logic until a component has been mounted.
 
 ```js
 const aperture = initialProps => component => {
-    const mount$ = component.mount
+    const mount$ = component.mount$
 
     return mount$.pipe(mapTo('Component mounted!'))
 }
@@ -158,13 +158,13 @@ const aperture = initialProps => component => {
 
 ### Observing Component Unmount
 
-`component.unmount` is a stream which will emit a single value when a component unmounts.
+`component.unmount$` is a stream which will emit a single value when a component unmounts.
 
 It can be useful to trigger side-effects when a component is about to be unmounted.
 
 ```js
 const aperture = initialProps => component => {
-    const unmount$ = component.unmount
+    const unmount$ = component.unmount$
 
     return unmount$.pipe(mapTo('Component unmounted!'))
 }


### PR DESCRIPTION
Combines:

- Rename event method to fromEvent (#87)
- Use `fromEvent` internally for mount and unmount (#90)
- Add $ suffix to mount and unmount properties to signify streams (#91)