### PR TITLE
Add value transformer to observe and event functions

### DIFF
--- a/base/__tests__/react/xstream/index.tsx
+++ b/base/__tests__/react/xstream/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './aperture'
 import { mount } from 'enzyme'
 
-describe('refract-xstream', () => {
+describe.only('refract-xstream', () => {
     const noop = (...args) => void 0
 
     const handler: Handler<Props, Effect> = props => (value: Effect) => {

--- a/base/__tests__/react/xstream/index.tsx
+++ b/base/__tests__/react/xstream/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './aperture'
 import { mount } from 'enzyme'
 
-describe.only('refract-xstream', () => {
+describe('refract-xstream', () => {
     const noop = (...args) => void 0
 
     const handler: Handler<Props, Effect> = props => (value: Effect) => {

--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -1,18 +1,3 @@
-import { Listener } from './observable'
-
-type ListenerAndTransformer<T> = [Partial<Listener<T>>, (value: any) => T]
-
-export interface KeyedListenersAndTransformers {
-    [key: string]: Array<ListenerAndTransformer<any>>
-}
-
-export interface Listeners {
-    allProps: Array<Partial<Listener<any>>>
-    props: KeyedListenersAndTransformers
-    fnProps: KeyedListenersAndTransformers
-    event: KeyedListenersAndTransformers
-}
-
 export type Handler<P, E> = (intialProps: P) => (val: E) => void
 
 export type ErrorHandler<P> = (intialProps: P) => (error: any) => void

--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -1,14 +1,16 @@
 import { Listener } from './observable'
 
-export interface KeyedListeners {
-    [key: string]: Array<Partial<Listener<any>>>
+type ListenerAndTransformer<T> = [Partial<Listener<T>>, (value: any) => T]
+
+export interface KeyedListenersAndTransformers {
+    [key: string]: Array<ListenerAndTransformer<any>>
 }
 
 export interface Listeners {
     allProps: Array<Partial<Listener<any>>>
-    props: KeyedListeners
-    fnProps: KeyedListeners
-    event: KeyedListeners
+    props: KeyedListenersAndTransformers
+    fnProps: KeyedListenersAndTransformers
+    event: KeyedListenersAndTransformers
 }
 
 export type Handler<P, E> = (intialProps: P) => (val: E) => void

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,5 +1,5 @@
 import $$observable from 'symbol-observable'
-import { Listeners, Handler, ErrorHandler, PushEvent } from './baseTypes'
+import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { PROPS_EFFECT } from './effects'
 import {
     Listener,

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -10,6 +10,7 @@ import {
     Aperture
 } from './observable'
 import {
+    shallowEquals,
     createEventData,
     createPropsData,
     createCallbackData,
@@ -19,11 +20,6 @@ import {
 
 const identity = _ => _
 const selectFirstArg = args => args[0]
-
-const shallowEquals = (left, right) =>
-    left === right ||
-    (Object.keys(left).length === Object.keys(right).length &&
-        Object.keys(left).every(leftKey => left[leftKey] === right[leftKey]))
 
 const configureComponent = <P, E>(
     handler: Handler<P, E>,

--- a/base/react/data.ts
+++ b/base/react/data.ts
@@ -1,24 +1,46 @@
 export const MOUNT_EVENT: string = '@@refract/event/mount'
 export const UNMOUNT_EVENT: string = '@@refract/event/unmount'
 
-enum DataType {
+export enum DataType {
     EVENT = 'event',
     PROPS = 'props',
     CALLBACK = 'callback'
 }
 
-export interface Data {
+export type Data<P> = PropsData<P> | CallbackData | EventData
+
+export interface PropsData<P> {
     type: DataType
-    payload: any
+    payload: Partial<P>
 }
 
-export const isEvent = eventName => data =>
-    data.type === DataType.EVENT && data.payload.name === eventName
-export const isProps = data => data.type === DataType.PROPS
-export const isCallback = propName => data =>
-    data.type === DataType.CALLBACK && data.payload.name === propName
+export interface CallbackData {
+    type: DataType
+    payload: {
+        name: string
+        args: any[]
+    }
+}
 
-export const createEventData = (name, value) => ({
+export interface EventData {
+    type: DataType
+    payload: {
+        name: string
+        value?: any
+    }
+}
+
+export const isEvent = <P>(eventName) => (data: Data<P>, index?) =>
+    data.type === DataType.EVENT &&
+    (data as EventData).payload.name === eventName
+
+export const isProps = <P>(data: Data<P>) => data.type === DataType.PROPS
+
+export const isCallback = <P>(propName) => (data: Data<P>) =>
+    data.type === DataType.CALLBACK &&
+    (data as CallbackData).payload.name === propName
+
+export const createEventData = (name: string, value?: any): EventData => ({
     type: DataType.EVENT,
     payload: {
         name,
@@ -26,15 +48,23 @@ export const createEventData = (name, value) => ({
     }
 })
 
-export const createPropsData = <P>(props: P) => ({
+export const createPropsData = <P>(props: P): PropsData<P> => ({
     type: DataType.PROPS,
     payload: props
 })
 
-export const createCallbackData = (name, args: any[]) => ({
+export const createCallbackData = (
+    name: string,
+    args: any[]
+): CallbackData => ({
     type: DataType.CALLBACK,
     payload: {
         name,
         args
     }
 })
+
+export const shallowEquals = (left, right) =>
+    left === right ||
+    (Object.keys(left).length === Object.keys(right).length &&
+        Object.keys(left).every(leftKey => left[leftKey] === right[leftKey]))

--- a/base/react/data.ts
+++ b/base/react/data.ts
@@ -1,0 +1,40 @@
+export const MOUNT_EVENT: string = '@@refract/event/mount'
+export const UNMOUNT_EVENT: string = '@@refract/event/unmount'
+
+enum DataType {
+    EVENT = 'event',
+    PROPS = 'props',
+    CALLBACK = 'callback'
+}
+
+export interface Data {
+    type: DataType
+    payload: any
+}
+
+export const isEvent = eventName => data =>
+    data.type === DataType.EVENT && data.payload.name === eventName
+export const isProps = data => data.type === DataType.PROPS
+export const isCallback = propName => data =>
+    data.type === DataType.CALLBACK && data.payload.name === propName
+
+export const createEventData = (name, value) => ({
+    type: DataType.EVENT,
+    payload: {
+        name,
+        value
+    }
+})
+
+export const createPropsData = <P>(props: P) => ({
+    type: DataType.PROPS,
+    payload: props
+})
+
+export const createCallbackData = (name, args: any[]) => ({
+    type: DataType.CALLBACK,
+    payload: {
+        name,
+        args
+    }
+})

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -4,8 +4,14 @@ import { PushEvent } from './baseTypes'
 export { Listener, Subscription }
 
 export interface ObservableComponent {
-    observe: <T>(propName?: string) => Observable<T>
-    event: <T>(eventName: string) => Observable<T>
+    observe: <T>(
+        propName?: string,
+        valueTransformer?: (val: any) => T
+    ) => Observable<T>
+    event: <T>(
+        eventName: string,
+        valueTransformer?: (val: any) => T
+    ) => Observable<T>
     mount: Observable<any>
     unmount: Observable<any>
     pushEvent: PushEvent

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -15,8 +15,14 @@ export interface Subscription {
 }
 
 export interface ObservableComponent {
-    observe: <T = any>(propName?: string) => Source<T>
-    event: <T>(eventName: string) => Source<T>
+    observe: <T = any>(
+        propName?: string,
+        valueTransformer?: (value: any) => T
+    ) => Source<T>
+    event: <T>(
+        eventName: string,
+        valueTransformer?: (val: any) => T
+    ) => Source<T>
     mount: Source<any>
     unmount: Source<any>
     pushEvent: PushEvent

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -6,7 +6,11 @@ import {
     UNMOUNT_EVENT,
     isProps,
     isCallback,
-    Data
+    Data,
+    PropsData,
+    EventData,
+    CallbackData,
+    shallowEquals
 } from './data'
 
 export { Listener }
@@ -44,28 +48,32 @@ export const subscribeToSink = <T>(
         complete: () => void 0
     })
 
-export const createComponent = (
+export const createComponent = <P>(
     instance,
     dataObservable,
     pushEvent
 ): ObservableComponent => {
-    const data$ = from<Data>(dataObservable)
+    const data$ = from<Data<P>>(dataObservable)
 
     return {
         mount: data$.filter(isEvent(MOUNT_EVENT)).map(() => undefined),
         unmount: data$.filter(isEvent(UNMOUNT_EVENT)).map(() => undefined),
         observe: <T>(propName?, valueTransformer?) => {
             if (propName && typeof instance.props[propName] === 'function') {
-                return data$.filter(isCallback(propName)).map(data => {
-                    const { args } = data.payload
-                    return valueTransformer ? valueTransformer(args) : args[0]
-                })
+                return data$
+                    .filter(isCallback(propName))
+                    .map((data: CallbackData) => {
+                        const { args } = data.payload
+                        return valueTransformer
+                            ? valueTransformer(args)
+                            : args[0]
+                    })
             }
 
             if (propName) {
                 return data$
                     .filter(isProps)
-                    .map(data => {
+                    .map((data: PropsData<P>) => {
                         const prop = data.payload[propName]
 
                         return valueTransformer ? valueTransformer(prop) : prop
@@ -75,11 +83,11 @@ export const createComponent = (
 
             return data$
                 .filter(isProps)
-                .map(data => data.payload)
-                .skipRepeats()
+                .map((data: PropsData<P>) => data.payload)
+                .skipRepeatsWith(shallowEquals)
         },
         event: <T>(eventName, valueTransformer?) =>
-            data$.filter(isEvent(eventName)).map(data => {
+            data$.filter(isEvent(eventName)).map((data: EventData) => {
                 const { value } = data.payload
 
                 return valueTransformer ? valueTransformer(value) : value

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -5,8 +5,14 @@ import { PushEvent } from './baseTypes'
 export { Listener }
 
 export interface ObservableComponent {
-    observe: <T>(propName?: string) => Stream<T>
-    event: <T>(eventName: string) => Stream<T>
+    observe: <T>(
+        propName?: string,
+        valueTransformer?: (val: any) => T
+    ) => Stream<T>
+    event: <T>(
+        eventName: string,
+        valueTransformer?: (val: any) => T
+    ) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>
     pushEvent: PushEvent

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -4,8 +4,14 @@ import { PushEvent } from './baseTypes'
 export { Listener, Subscription }
 
 export interface ObservableComponent {
-    observe: <T>(propName?: string) => Stream<T>
-    event: <T>(eventName: string) => Stream<T>
+    observe: <T>(
+        propName?: string,
+        valueTransformer?: (val: any) => T
+    ) => Stream<T>
+    event: <T>(
+        eventName: string,
+        valueTransformer?: (val: any) => T
+    ) => Stream<T>
     mount: Stream<any>
     unmount: Stream<any>
     pushEvent: PushEvent

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -56,14 +56,11 @@ export const withEffects = <P, E, CP = P>(
 
         public componentWillReceiveProps(nextProps: P) {
             this.reDecorateProps(nextProps)
+            this.pushProps(nextProps)
         }
 
         public shouldComponentUpdate(nextProps, nextState) {
             return this.havePropsChanged(nextProps, nextState)
-        }
-
-        public componentDidUpdate(prevProps: P) {
-            this.pushProps(prevProps)
         }
 
         public componentWillUnmount() {

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -64,14 +64,11 @@ export const withEffects = <P, E, CP = P>(
 
         public componentWillUpdate(nextProps: P) {
             this.reDecorateProps(nextProps)
+            this.pushProps(nextProps)
         }
 
         public shouldComponentUpdate(nextProps, nextState) {
             return this.havePropsChanged(nextProps, nextState)
-        }
-
-        public componentDidUpdate(lastProps: P) {
-            this.pushProps(lastProps)
         }
 
         public componentWillUnmount() {

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -63,14 +63,11 @@ export const withEffects = <P, E, CP = P>(
 
         public componentWillReceiveProps(nextProps) {
             this.reDecorateProps(nextProps)
+            this.pushProps(nextProps)
         }
 
         public shouldComponentUpdate(nextProps, nextState) {
             return this.havePropsChanged(nextProps, nextState)
-        }
-
-        public componentDidUpdate(prevProps: P) {
-            this.pushProps(prevProps)
         }
 
         public componentWillUnmount() {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "callbag": "~1.1.0",
         "callbag-basics": "~3.0.0",
         "callbag-drop-repeats": "~1.0.0",
+        "callbag-filter": "~1.0.1",
         "callbag-from-obs": "~1.2.0",
         "callbag-map": "~1.0.1",
         "callbag-pipe": "~1.1.1",

--- a/packages.js
+++ b/packages.js
@@ -27,6 +27,15 @@ const peerDependencies = {
     }
 }
 const baseDependencies = {
+    react: {
+        'symbol-observable': '~1.2.0'
+    },
+    inferno: {
+        'symbol-observable': '~1.2.0'
+    },
+    preact: {
+        'symbol-observable': '~1.2.0'
+    },
     callbag: {
         callbag: '~1.1.0',
         'callbag-from-obs': '~1.2.0',
@@ -37,16 +46,19 @@ const baseDependencies = {
     }
 }
 
+const callbagUIPackages = {
+    'callbag-from-obs': '~1.2.0',
+    'callbag-to-obs': '~1.0.0',
+    'callbag-map': '~1.0.1',
+    'callbag-pipe': '~1.1.1',
+    'callbag-filter': '~1.0.1',
+    'callbag-drop-repeats': '~1.0.0'
+}
+
 const extraDependencies = {
-    'refract-callbag': {
-        'callbag-to-obs': '~1.0.0'
-    },
-    'refract-inferno-callbag': {
-        'callbag-to-obs': '~1.0.0'
-    },
-    'refract-preact-callbag': {
-        'callbag-to-obs': '~1.0.0'
-    },
+    'refract-callbag': callbagUIPackages,
+    'refract-inferno-callbag': callbagUIPackages,
+    'refract-preact-callbag': callbagUIPackages,
     'refract-redux-callbag': {
         'callbag-drop-repeats': '~1.0.0',
         'callbag-map': '~1.0.1',

--- a/packages/refract-callbag/package.json
+++ b/packages/refract-callbag/package.json
@@ -13,7 +13,11 @@
     },
     "dependencies": {
         "callbag": "~1.1.0",
+        "callbag-drop-repeats": "~1.0.0",
+        "callbag-filter": "~1.0.1",
         "callbag-from-obs": "~1.2.0",
+        "callbag-map": "~1.0.1",
+        "callbag-pipe": "~1.1.1",
         "callbag-to-obs": "~1.0.0",
         "symbol-observable": "~1.2.0"
     },

--- a/packages/refract-inferno-callbag/package.json
+++ b/packages/refract-inferno-callbag/package.json
@@ -14,7 +14,11 @@
     },
     "dependencies": {
         "callbag": "~1.1.0",
+        "callbag-drop-repeats": "~1.0.0",
+        "callbag-filter": "~1.0.1",
         "callbag-from-obs": "~1.2.0",
+        "callbag-map": "~1.0.1",
+        "callbag-pipe": "~1.1.1",
         "callbag-to-obs": "~1.0.0",
         "symbol-observable": "~1.2.0"
     },

--- a/packages/refract-inferno-rxjs/package.json
+++ b/packages/refract-inferno-rxjs/package.json
@@ -28,5 +28,8 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org"
+    "homepage": "https://refract.js.org",
+    "dependencies": {
+        "symbol-observable": "~1.2.0"
+    }
 }

--- a/packages/refract-inferno-xstream/package.json
+++ b/packages/refract-inferno-xstream/package.json
@@ -28,5 +28,8 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org"
+    "homepage": "https://refract.js.org",
+    "dependencies": {
+        "symbol-observable": "~1.2.0"
+    }
 }

--- a/packages/refract-preact-callbag/package.json
+++ b/packages/refract-preact-callbag/package.json
@@ -13,7 +13,11 @@
     },
     "dependencies": {
         "callbag": "~1.1.0",
+        "callbag-drop-repeats": "~1.0.0",
+        "callbag-filter": "~1.0.1",
         "callbag-from-obs": "~1.2.0",
+        "callbag-map": "~1.0.1",
+        "callbag-pipe": "~1.1.1",
         "callbag-to-obs": "~1.0.0",
         "symbol-observable": "~1.2.0"
     },

--- a/packages/refract-preact-rxjs/package.json
+++ b/packages/refract-preact-rxjs/package.json
@@ -27,5 +27,8 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org"
+    "homepage": "https://refract.js.org",
+    "dependencies": {
+        "symbol-observable": "~1.2.0"
+    }
 }

--- a/packages/refract-preact-xstream/package.json
+++ b/packages/refract-preact-xstream/package.json
@@ -27,5 +27,8 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org"
+    "homepage": "https://refract.js.org",
+    "dependencies": {
+        "symbol-observable": "~1.2.0"
+    }
 }

--- a/packages/refract-rxjs/package.json
+++ b/packages/refract-rxjs/package.json
@@ -27,5 +27,8 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org"
+    "homepage": "https://refract.js.org",
+    "dependencies": {
+        "symbol-observable": "~1.2.0"
+    }
 }

--- a/packages/refract-xstream/package.json
+++ b/packages/refract-xstream/package.json
@@ -27,5 +27,8 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org"
+    "homepage": "https://refract.js.org",
+    "dependencies": {
+        "symbol-observable": "~1.2.0"
+    }
 }

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -11,6 +11,7 @@ const getPackages = require('../packages')
 const filesPerBaseDir = {
     react: [
         'baseTypes.ts',
+        'data.ts',
         'effects.ts',
         'index.ts',
         ({ mainLib }) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,7 +618,7 @@ callbag-drop-repeats@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callbag-drop-repeats/-/callbag-drop-repeats-1.0.0.tgz#bfa4d765880875435746948ec9076b979569e89b"
 
-callbag-filter@1.0.x:
+callbag-filter@1.0.x, callbag-filter@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/callbag-filter/-/callbag-filter-1.0.1.tgz#82d3b80231cf890fd6e0d61c3a33cd09dcb52570"
 


### PR DESCRIPTION
I think I'm going to simplify the code by having one observable where everything is pushed:
- props
- events
- function calls

And then observe / event are just a filter + map + drop repeats.