### PR TITLE
Add optional seed value to useEvent

### DIFF
--- a/docs/usage/observing-react.md
+++ b/docs/usage/observing-react.md
@@ -155,11 +155,14 @@ const aperture = initialProps => component => {
 
 ### Using events
 
-A convenient helper function `useEvent` is available on `component`, to make it easier to use events: it returns a tuple containing the result of `fromEvent(eventName)` and `pushEvent(eventName)`.
+A convenient helper function `useEvent` is available on `component`, to make it easier to use events: it returns a tuple containing the result of `fromEvent(eventName)` and `pushEvent(eventName)`. `useEvent` takes two arguments:
+
+*   `eventName` _(string)_: the name of the event
+*   `seedValue` _(any)_: an optional seed value to initialise the streem of event values with
 
 ```js
 const aperture = initialProps => component => {
-    const [ value$, setValue ] = component.useEvent('eventName')
+    const [ value$, setValue ] = component.useEvent('eventName', '')
 
     return value$.pipe(map(value => toProps({
         value,

--- a/packages.js
+++ b/packages.js
@@ -51,7 +51,8 @@ const callbagUIPackages = {
     'callbag-map': '~1.0.1',
     'callbag-pipe': '~1.1.1',
     'callbag-filter': '~1.0.1',
-    'callbag-drop-repeats': '~1.0.0'
+    'callbag-drop-repeats': '~1.0.0',
+    'callbag-start-with': '~3.1.0'
 }
 
 const extraDependencies = {

--- a/packages/refract-callbag/package.json
+++ b/packages/refract-callbag/package.json
@@ -18,6 +18,7 @@
         "callbag-from-obs": "~1.2.0",
         "callbag-map": "~1.0.1",
         "callbag-pipe": "~1.1.1",
+        "callbag-start-with": "~3.1.0",
         "callbag-to-obs": "~1.0.0",
         "symbol-observable": "~1.2.0"
     },

--- a/packages/refract-inferno-callbag/package.json
+++ b/packages/refract-inferno-callbag/package.json
@@ -19,6 +19,7 @@
         "callbag-from-obs": "~1.2.0",
         "callbag-map": "~1.0.1",
         "callbag-pipe": "~1.1.1",
+        "callbag-start-with": "~3.1.0",
         "callbag-to-obs": "~1.0.0",
         "symbol-observable": "~1.2.0"
     },

--- a/packages/refract-preact-callbag/package.json
+++ b/packages/refract-preact-callbag/package.json
@@ -18,6 +18,7 @@
         "callbag-from-obs": "~1.2.0",
         "callbag-map": "~1.0.1",
         "callbag-pipe": "~1.1.1",
+        "callbag-start-with": "~3.1.0",
         "callbag-to-obs": "~1.0.0",
         "symbol-observable": "~1.2.0"
     },


### PR DESCRIPTION
When using `useEvent` to stream values rather than events (i.e. state), a seed value needs added. So I have added an optional `seedValue` to `useEvent`.