### PR TITLE
Fix import of callbag-start-with

### DIFF
--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -6,7 +6,7 @@ const dropRepeats = require('callbag-drop-repeats')
 const map = require('callbag-map')
 const pipe = require('callbag-pipe')
 const filter = require('callbag-filter')
-const startWith = require('callbag-start-with')
+import startWith from 'callbag-start-with'
 
 import { PushEvent } from './baseTypes'
 import {


### PR DESCRIPTION
Turns out this package has a ES2015 module. Once this is published I will look into removing all `require()` since our `tsConfig.json` seems rightly configured for interop.

Build output was checked.