### PR TITLE
[Breaking] Flatten withEffects and aperture APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The example below uses `refract-rxjs` to send data to localstorage.
 Every time the `username` prop changes, its new value is sent into the stream. The stream debounces the input for two seconds, then maps it into an object (with a `type` of `localstorage`) under the key `value`. Each time an effect with the correct type is emitted from this pipeline, the handler calls `localstorage.setItem` with the effect's `name` and `value` properties.
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     return component.observe('username').pipe(
         debounce(2000),
         map(username => ({
@@ -104,7 +104,7 @@ const handler = initialProps => effect => {
     }
 }
 
-const WrappedComponent = withEffects(handler)(aperture)(BaseComponent)
+const WrappedComponent = withEffects(aperture, { handler })(BaseComponent)
 ```
 
 ### Aperture

--- a/base/__tests__/inferno/callbag/index.tsx
+++ b/base/__tests__/inferno/callbag/index.tsx
@@ -98,10 +98,8 @@ describe('refract-inferno-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -133,10 +131,8 @@ describe('refract-inferno-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -160,14 +156,13 @@ describe('refract-inferno-callbag', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
+        const WithEffects = withEffects<Props, VNode>(aperture)()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/inferno/callbag/index.tsx
+++ b/base/__tests__/inferno/callbag/index.tsx
@@ -25,17 +25,16 @@ describe('refract-inferno-callbag', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, clickLink }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, clickLink }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={() => clickLink()} />
@@ -99,9 +98,10 @@ describe('refract-inferno-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -133,9 +133,10 @@ describe('refract-inferno-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -159,14 +160,14 @@ describe('refract-inferno-callbag', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/inferno/most/index.tsx
+++ b/base/__tests__/inferno/most/index.tsx
@@ -25,17 +25,16 @@ describe('refract-inferno-most', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, pushEvent }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, pushEvent }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={pushEvent('linkClick')} />
@@ -99,9 +98,10 @@ describe('refract-inferno-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -133,9 +133,10 @@ describe('refract-inferno-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -159,14 +160,14 @@ describe('refract-inferno-most', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/inferno/most/index.tsx
+++ b/base/__tests__/inferno/most/index.tsx
@@ -98,10 +98,8 @@ describe('refract-inferno-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -133,10 +131,8 @@ describe('refract-inferno-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -160,14 +156,13 @@ describe('refract-inferno-most', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
+        const WithEffects = withEffects<Props, VNode>(aperture)()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/inferno/rxjs/index.tsx
+++ b/base/__tests__/inferno/rxjs/index.tsx
@@ -98,10 +98,8 @@ describe('refract-inferno-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -133,10 +131,8 @@ describe('refract-inferno-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -160,14 +156,13 @@ describe('refract-inferno-rxjs', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
+        const WithEffects = withEffects<Props, VNode>(aperture)()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/inferno/rxjs/index.tsx
+++ b/base/__tests__/inferno/rxjs/index.tsx
@@ -25,17 +25,16 @@ describe('refract-inferno-rxjs', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, clickLink }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, clickLink }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={() => clickLink()} />
@@ -99,9 +98,10 @@ describe('refract-inferno-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -133,9 +133,10 @@ describe('refract-inferno-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -159,14 +160,14 @@ describe('refract-inferno-rxjs', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/inferno/xstream/index.tsx
+++ b/base/__tests__/inferno/xstream/index.tsx
@@ -98,10 +98,8 @@ describe('refract-inferno-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -133,10 +131,8 @@ describe('refract-inferno-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
 
         const node = mount(
@@ -160,14 +156,13 @@ describe('refract-inferno-xstream', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
+        const WithEffects = withEffects<Props, VNode>(aperture)()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/inferno/xstream/index.tsx
+++ b/base/__tests__/inferno/xstream/index.tsx
@@ -25,17 +25,16 @@ describe('refract-inferno-xstream', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, clickLink }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, clickLink }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={() => clickLink()} />
@@ -99,9 +98,10 @@ describe('refract-inferno-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -133,9 +133,10 @@ describe('refract-inferno-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(
@@ -159,14 +160,14 @@ describe('refract-inferno-xstream', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<VNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, VNode>(hander)(aperture)()
+        const WithEffects = withEffects<Props, VNode>(aperture, { handler })()
 
         const node = mount(
             // @ts-ignore

--- a/base/__tests__/preact/callbag/index.tsx
+++ b/base/__tests__/preact/callbag/index.tsx
@@ -22,8 +22,8 @@ describe('refract-preact-callbag', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         {handler: () => effectValueHandler }
-    //     )(aperture)(({ setValue, pushEvent }) => (
+    //         aperture, { handler: () => effectValueHandler }
+    //     )(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />
     //             <a onClick={pushEvent('linkClick')} />

--- a/base/__tests__/preact/callbag/index.tsx
+++ b/base/__tests__/preact/callbag/index.tsx
@@ -15,16 +15,14 @@ describe('refract-preact-callbag', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     // it('should observe component changes', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         () => effectValueHandler
+    //         {handler: () => effectValueHandler }
     //     )(aperture)(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />

--- a/base/__tests__/preact/most/index.tsx
+++ b/base/__tests__/preact/most/index.tsx
@@ -15,16 +15,14 @@ describe('refract-preact-most', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     // it('should observe component changes', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         () => effectValueHandler
+    //         {handler: () => effectValueHandler }
     //     )(aperture)(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />

--- a/base/__tests__/preact/most/index.tsx
+++ b/base/__tests__/preact/most/index.tsx
@@ -22,8 +22,8 @@ describe('refract-preact-most', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         {handler: () => effectValueHandler }
-    //     )(aperture)(({ setValue, pushEvent }) => (
+    //         aperture, { handler: () => effectValueHandler }
+    //     )(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />
     //             <a onClick={pushEvent('linkClick')} />

--- a/base/__tests__/preact/rxjs/index.tsx
+++ b/base/__tests__/preact/rxjs/index.tsx
@@ -22,8 +22,8 @@ describe('refract-preact-rxjs', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         {handler: () => effectValueHandler }
-    //     )(aperture)(({ setValue, pushEvent }) => (
+    //         aperture, { handler: () => effectValueHandler }
+    //     )(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />
     //             <a onClick={pushEvent('linkClick')} />

--- a/base/__tests__/preact/rxjs/index.tsx
+++ b/base/__tests__/preact/rxjs/index.tsx
@@ -15,16 +15,14 @@ describe('refract-preact-rxjs', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     // it('should observe component changes', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         () => effectValueHandler
+    //         {handler: () => effectValueHandler }
     //     )(aperture)(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />

--- a/base/__tests__/preact/xstream/index.tsx
+++ b/base/__tests__/preact/xstream/index.tsx
@@ -15,16 +15,14 @@ describe('refract-preact-xstream', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     // it('should observe component changes', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         () => effectValueHandler
+    //         {handler: () => effectValueHandler }
     //     )(aperture)(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />

--- a/base/__tests__/preact/xstream/index.tsx
+++ b/base/__tests__/preact/xstream/index.tsx
@@ -22,7 +22,7 @@ describe('refract-preact-xstream', () => {
     //     const effectValueHandler = jest.fn()
     //     const setValue = () => void 0
     //     const WithEffects = withEffects<Props, Effect>(
-    //         {handler: () => effectValueHandler }
+    //         aperture, { handler: () => effectValueHandler }
     //     )(aperture)(({ setValue, pushEvent }) => (
     //         <div>
     //             <button onClick={() => setValue(10)} />

--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -21,7 +21,7 @@ export interface ExtraProps {
     clickLink: () => void
 }
 
-export const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -66,7 +66,7 @@ interface SinkProps {
 export const asPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     pipe(
         component.observe(),
         map(({ prop }) => ({
@@ -78,7 +78,7 @@ export const asPropsAperture: Aperture<
 export const toPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     pipe(
         component.observe(),
         map(({ prop }) => ({
@@ -90,7 +90,7 @@ export const toPropsAperture: Aperture<
 export const createRenderingAperture = <VNode>(
     render: (prop: string) => VNode
 ) => {
-    const aperture: Aperture<SourceProps, VNode> = () => component =>
+    const aperture: Aperture<SourceProps, VNode> = component =>
         pipe(component.observe('prop'), map(render))
 
     return aperture

--- a/base/__tests__/react/callbag/index.tsx
+++ b/base/__tests__/react/callbag/index.tsx
@@ -96,10 +96,8 @@ describe('refract-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -128,10 +126,8 @@ describe('refract-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -152,16 +148,13 @@ describe('refract-callbag', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
-            handler
-        })()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture)()
 
         const node = mount(<WithEffects prop="hello" />)
 

--- a/base/__tests__/react/callbag/index.tsx
+++ b/base/__tests__/react/callbag/index.tsx
@@ -24,17 +24,16 @@ describe('refract-callbag', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, clickLink }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, clickLink }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={() => clickLink()} />
@@ -97,9 +96,10 @@ describe('refract-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -128,9 +128,10 @@ describe('refract-callbag', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -151,16 +152,16 @@ describe('refract-callbag', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
-            aperture
-        )()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
+            handler
+        })()
 
         const node = mount(<WithEffects prop="hello" />)
 

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -21,7 +21,7 @@ export interface ExtraProps {
     clickLink: () => void
 }
 
-export const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -69,7 +69,7 @@ interface SinkProps {
 export const asPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     component
         .observe()
         .map(({ prop }) => ({
@@ -80,7 +80,7 @@ export const asPropsAperture: Aperture<
 export const toPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     component
         .observe()
         .map(({ prop }) => ({
@@ -91,7 +91,7 @@ export const toPropsAperture: Aperture<
 export const createRenderingAperture = <VNode>(
     render: (prop: string) => VNode
 ) => {
-    const aperture: Aperture<SourceProps, VNode> = () => component =>
+    const aperture: Aperture<SourceProps, VNode> = component =>
         component.observe('prop').map(render)
 
     return aperture

--- a/base/__tests__/react/most/index.tsx
+++ b/base/__tests__/react/most/index.tsx
@@ -96,10 +96,8 @@ describe('refract-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -128,10 +126,8 @@ describe('refract-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
         const node = mount(<WithEffects prop="hello" />)
 
@@ -151,16 +147,13 @@ describe('refract-most', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
-            handler
-        })()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture)()
 
         const node = mount(<WithEffects prop="hello" />)
 

--- a/base/__tests__/react/most/index.tsx
+++ b/base/__tests__/react/most/index.tsx
@@ -24,17 +24,16 @@ describe('refract-most', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, clickLink, pushEvent }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, clickLink, pushEvent }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={pushEvent('linkClick')} />
@@ -97,9 +96,10 @@ describe('refract-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -128,9 +128,10 @@ describe('refract-most', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
         const node = mount(<WithEffects prop="hello" />)
 
@@ -150,16 +151,16 @@ describe('refract-most', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
-            aperture
-        )()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
+            handler
+        })()
 
         const node = mount(<WithEffects prop="hello" />)
 

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -23,7 +23,7 @@ export interface ExtraProps {
     clickLink: () => void
 }
 
-export const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -81,7 +81,7 @@ interface SinkProps {
 export const asPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     component.observe().pipe(
         map(({ prop }) => ({
             newProp: `${prop} world`
@@ -92,7 +92,7 @@ export const asPropsAperture: Aperture<
 export const toPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     component.observe().pipe(
         map(({ prop }) => ({
             newProp: `${prop} world`
@@ -103,7 +103,7 @@ export const toPropsAperture: Aperture<
 export const createRenderingAperture = <VNode>(
     render: (prop: string) => VNode
 ) => {
-    const aperture: Aperture<SourceProps, VNode> = () => component =>
+    const aperture: Aperture<SourceProps, VNode> = component =>
         component.observe('prop').pipe(map(render))
 
     return aperture

--- a/base/__tests__/react/rxjs/index.tsx
+++ b/base/__tests__/react/rxjs/index.tsx
@@ -95,10 +95,8 @@ describe('refract-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -127,10 +125,8 @@ describe('refract-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -151,16 +147,13 @@ describe('refract-rxjs', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
-            handler
-        })()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture)()
 
         const node = mount(<WithEffects prop="hello" />)
 

--- a/base/__tests__/react/rxjs/index.tsx
+++ b/base/__tests__/react/rxjs/index.tsx
@@ -25,17 +25,16 @@ describe('refract-rxjs', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, clickLink }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, clickLink }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={() => clickLink()} />
@@ -96,9 +95,10 @@ describe('refract-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -127,9 +127,10 @@ describe('refract-rxjs', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -150,16 +151,16 @@ describe('refract-rxjs', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
-            aperture
-        )()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
+            handler
+        })()
 
         const node = mount(<WithEffects prop="hello" />)
 
@@ -186,13 +187,13 @@ describe('refract-rxjs', () => {
     //     })
 
     //     const BaseComponent = () => <div />
-    //     const hander = jest.fn().mockReturnValue(() => void 0)
-    //     const errorHander = jest.fn().mockReturnValue(() => void 0)
+    //     const handler = jest.fn().mockReturnValue(() => void 0)
+    //     const errorHandler = jest.fn().mockReturnValue(() => void 0)
     //     const aperture = jest.fn().mockReturnValue(() => emptyStream())
 
     //     const WithEffects = withEffects<Props, PropEffect, Props, Ctx>(
-    //         hander,
-    //         errorHander,
+    //         handler,
+    //         errorHandler,
     //         Context
     //     )(aperture)(BaseComponent)
 

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -20,7 +20,7 @@ export interface ExtraProps {
     clickLink: () => void
 }
 
-export const aperture: Aperture<Props, Effect> = props => component => {
+export const aperture: Aperture<Props, Effect> = component => {
     const value$ = component.observe<number>('value')
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
@@ -64,7 +64,7 @@ interface SinkProps {
 export const asPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     component
         .observe()
         .map(({ prop }) => ({
@@ -75,7 +75,7 @@ export const asPropsAperture: Aperture<
 export const toPropsAperture: Aperture<
     SourceProps,
     PropEffect<SinkProps>
-> = () => component =>
+> = component =>
     component
         .observe()
         .map(({ prop }) => ({
@@ -86,7 +86,7 @@ export const toPropsAperture: Aperture<
 export const createRenderingAperture = <VNode>(
     render: (prop: string) => VNode
 ) => {
-    const aperture: Aperture<SourceProps, VNode> = () => component =>
+    const aperture: Aperture<SourceProps, VNode> = component =>
         component.observe('prop').map(render)
 
     return aperture

--- a/base/__tests__/react/xstream/index.tsx
+++ b/base/__tests__/react/xstream/index.tsx
@@ -96,10 +96,8 @@ describe('refract-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            asPropsAperture,
-            { handler }
+            asPropsAperture
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -128,10 +126,8 @@ describe('refract-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const handler = () => () => void 0
         const WithEffects = withEffects<Props, PropEffect, ChildProps>(
-            toPropsAperture,
-            { handler }
+            toPropsAperture
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -152,16 +148,13 @@ describe('refract-xstream', () => {
     })
 
     it('should render virtual elements', () => {
-        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
-            handler
-        })()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture)()
 
         const node = mount(<WithEffects prop="hello" />)
 

--- a/base/__tests__/react/xstream/index.tsx
+++ b/base/__tests__/react/xstream/index.tsx
@@ -24,17 +24,16 @@ describe('refract-xstream', () => {
     }
 
     it('should create a HoC', () => {
-        const WithEffects = withEffects<Props, Effect>(handler)(aperture)(
-            () => <div />
-        )
+        withEffects<Props, Effect>(aperture, { handler })(() => <div />)
     })
 
     it('should observe component changes', () => {
         const effectValueHandler = jest.fn()
         const setValue = () => void 0
         const WithEffects = withEffects<Props, Effect, Props & ExtraProps>(
-            () => effectValueHandler
-        )(aperture)(({ setValue, clickLink }) => (
+            aperture,
+            { handler: () => effectValueHandler }
+        )(({ setValue, clickLink }) => (
             <div>
                 <button onClick={() => setValue(10)} />
                 <a onClick={() => clickLink()} />
@@ -97,9 +96,10 @@ describe('refract-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            asPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            asPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -128,9 +128,10 @@ describe('refract-xstream', () => {
             newProp: string
         }
         const BaseComponent = jest.fn().mockReturnValue(<div />)
-        const hander = () => () => void 0
-        const WithEffects = withEffects<Props, PropEffect, ChildProps>(hander)(
-            toPropsAperture
+        const handler = () => () => void 0
+        const WithEffects = withEffects<Props, PropEffect, ChildProps>(
+            toPropsAperture,
+            { handler }
         )(BaseComponent)
 
         const node = mount(<WithEffects prop="hello" />)
@@ -151,16 +152,16 @@ describe('refract-xstream', () => {
     })
 
     it('should render virtual elements', () => {
-        const hander = () => () => void 0
+        const handler = () => () => void 0
         interface Props {
             prop: string
         }
         const aperture = createRenderingAperture<React.ReactNode>(prop => (
             <div>{prop}</div>
         ))
-        const WithEffects = withEffects<Props, React.ReactNode>(hander)(
-            aperture
-        )()
+        const WithEffects = withEffects<Props, React.ReactNode>(aperture, {
+            handler
+        })()
 
         const node = mount(<WithEffects prop="hello" />)
 

--- a/base/react/README.tpl.md
+++ b/base/react/README.tpl.md
@@ -127,10 +127,12 @@ The `withEffects` higher-order component implements your side-effect logic as a 
 
 Signature: `(aperture, { handler }) => (Component) => { return WrappedComponent }`
 
-*   The hoc takes in three curried arguments:
-    *   A `handler` function
+*   The hoc takes in two arguments, followed by a component:
     *   An `aperture` function
-    *   A React `Component`
+    *   An optional `config` object accepting
+        *   a `handler` function
+        *   a `errorHandler` function
+        *   a `Context` object (React only)
 *   The hoc returns a `WrappedComponent` - an enhanced version of your original `Component` which includes your side-effect logic.
 
 # Learn Refract

--- a/base/react/README.tpl.md
+++ b/base/react/README.tpl.md
@@ -79,7 +79,7 @@ The example below uses `refract-rxjs` to send data to localstorage.
 Every time the `username` prop changes, its new value is sent into the stream. The stream debounces the input for two seconds, then maps it into an object (with a `type` of `localstorage`) under the key `value`. Each time an effect with the correct type is emitted from this pipeline, the handler calls `localstorage.setItem` with the effect's `name` and `value` properties.
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     return component.observe('username').pipe(
         debounce(2000),
         map(username => ({
@@ -98,14 +98,14 @@ const handler = initialProps => effect => {
     }
 }
 
-const WrappedComponent = withEffects(handler)(aperture)(BaseComponent)
+const WrappedComponent = withEffects(aperture, { handler })(BaseComponent)
 ```
 
 ### Aperture
 
 An `aperture` controls the streams of data entering Refract. It is a function which observes data sources within your app, passes this data through any necessary logic flows, and outputs a stream of `effect`s.
 
-Signature: `(initialProps) => (component) => { return effectStream }`.
+Signature: `(component, initialProps) => { return effectStream }`.
 
 *   The `initialProps` are all props passed into the `WrappedComponent`.
 *   The `component` is an object which lets you observe your React component.
@@ -125,7 +125,7 @@ Signature: `(initialProps) => (effect) => { /* handle effects here */ }`.
 
 The `withEffects` higher-order component implements your side-effect logic as a React component.
 
-Signature: `(handler) => (aperture) => (Component) => { return WrappedComponent }`
+Signature: `(aperture, { handler }) => (Component) => { return WrappedComponent }`
 
 *   The hoc takes in three curried arguments:
     *   A `handler` function

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -19,7 +19,7 @@ import {
 } from './data'
 
 const configureComponent = <P, E, Ctx>(
-    handler: Handler<P, E, Ctx>,
+    handler?: Handler<P, E, Ctx>,
     errorHandler?: ErrorHandler<P>
 ) => (
     aperture: Aperture<P, E, Ctx>,
@@ -49,7 +49,9 @@ const configureComponent = <P, E, Ctx>(
     }
 
     const finalHandler = (initialProps, initialContext) => {
-        const effectHandler = handler(initialProps, initialContext)
+        const effectHandler = handler
+            ? handler(initialProps, initialContext)
+            : () => void 0
 
         return effect => {
             if (isValidElement(effect)) {
@@ -126,7 +128,7 @@ const configureComponent = <P, E, Ctx>(
         pushEvent
     )
 
-    const sinkObservable = aperture(instance.props, instance.context)(component)
+    const sinkObservable = aperture(component, instance.props, instance.context)
 
     const sinkSubscription: Subscription = subscribeToSink<E>(
         sinkObservable,

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -19,13 +19,12 @@ import {
 } from './data'
 
 const configureComponent = <P, E, Ctx>(
-    handler?: Handler<P, E, Ctx>,
-    errorHandler?: ErrorHandler<P>
-) => (
     aperture: Aperture<P, E, Ctx>,
     instance: any,
     isValidElement: (val: any) => boolean = () => false,
-    isComponentClass: (val: any) => boolean = () => false
+    isComponentClass: (val: any) => boolean = () => false,
+    handler?: Handler<P, E, Ctx>,
+    errorHandler?: ErrorHandler<P>
 ) => {
     instance.state = {
         renderEffect: false,

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -11,7 +11,7 @@ import {
     distinctUntilChanged,
     startWith
 } from 'rxjs/operators'
-import { PushEvent } from './baseTypes'
+import { PushEvent, Handler, ErrorHandler } from './baseTypes'
 import {
     isEvent,
     MOUNT_EVENT,
@@ -46,9 +46,10 @@ export interface ObservableComponent {
 }
 
 export type Aperture<P, E, C = any> = (
+    component: ObservableComponent,
     initialProps: P,
-    initialContext: C
-) => (component: ObservableComponent) => Observable<E>
+    initialContext?: C
+) => Observable<E>
 
 export const subscribeToSink = <T>(
     sink: Observable<T>,

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -51,9 +51,10 @@ export interface ObservableComponent {
 }
 
 export type Aperture<P, E, C = any> = (
+    component: ObservableComponent,
     initialProps: P,
     initialContext: C
-) => (component: ObservableComponent) => Sink<E>
+) => Sink<E>
 
 export const subscribeToSink = <T>(
     sink: Sink<T>,

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -38,9 +38,10 @@ export interface Subscription {
 }
 
 export type Aperture<P, E, C = any> = (
+    component: ObservableComponent,
     initialProps: P,
     initialContext: C
-) => (component: ObservableComponent) => Stream<E>
+) => Stream<E>
 
 export const subscribeToSink = <T>(
     sink: Stream<T>,

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -35,9 +35,10 @@ export interface ObservableComponent {
 }
 
 export type Aperture<P, E, C = any> = (
+    component: ObservableComponent,
     initialProps: P,
     initialContext: C
-) => (component: ObservableComponent) => Stream<E>
+) => Stream<E>
 
 export const subscribeToSink = <T>(
     sink: Stream<T>,

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -13,6 +13,12 @@ export interface State {
     children: React.ReactNode | null
 }
 
+export interface Config<P, E, C = any> {
+    handler: Handler<P, E, C>
+    errorHandler: ErrorHandler<P, C>
+    Context: React.Context<C>
+}
+
 const isComponentClass = (ComponentClass: any): boolean =>
     Boolean(
         ComponentClass &&
@@ -23,14 +29,13 @@ const isComponentClass = (ComponentClass: any): boolean =>
 const Empty = () => null
 
 export const withEffects = <P, E, CP = P, C = any>(
-    handler: Handler<P, E, C>,
-    errorHandler?: ErrorHandler<P, C>,
-    Context?: React.Context<C>
-) => (aperture: Aperture<P, E, C>) => (
+    aperture: Aperture<P, E, C>,
+    config: Partial<Config<P, E, C>> = {}
+) => (
     BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): React.ComponentClass<P> =>
     class WithEffects extends React.Component<P, State> {
-        public static contextType = Context
+        public static contextType = config.Context
 
         private triggerMount: () => void
         private triggerUnmount: () => void
@@ -44,7 +49,7 @@ export const withEffects = <P, E, CP = P, C = any>(
         constructor(props: any, context: any) {
             super(props, context)
 
-            configureComponent(handler, errorHandler)(
+            configureComponent(config.handler, config.errorHandler)(
                 aperture,
                 this,
                 React.isValidElement,

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -14,9 +14,9 @@ export interface State {
 }
 
 export interface Config<P, E, C = any> {
-    handler: Handler<P, E, C>
-    errorHandler: ErrorHandler<P, C>
-    Context: React.Context<C>
+    handler?: Handler<P, E, C>
+    errorHandler?: ErrorHandler<P, C>
+    Context?: React.Context<C>
 }
 
 const isComponentClass = (ComponentClass: any): boolean =>
@@ -30,7 +30,7 @@ const Empty = () => null
 
 export const withEffects = <P, E, CP = P, C = any>(
     aperture: Aperture<P, E, C>,
-    config: Partial<Config<P, E, C>> = {}
+    config: Config<P, E, C> = {}
 ) => (
     BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): React.ComponentClass<P> =>

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -49,11 +49,13 @@ export const withEffects = <P, E, CP = P, C = any>(
         constructor(props: any, context: any) {
             super(props, context)
 
-            configureComponent(config.handler, config.errorHandler)(
+            configureComponent(
                 aperture,
                 this,
                 React.isValidElement,
-                isComponentClass
+                isComponentClass,
+                config.handler,
+                config.errorHandler
             )
         }
 

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -13,6 +13,11 @@ export interface State {
     children: VNode | null
 }
 
+export interface Config<P, E> {
+    handler: Handler<P, E>
+    errorHandler: ErrorHandler<P, E>
+}
+
 const Empty = () => null
 
 const isValidElement = (value: any): boolean =>
@@ -31,9 +36,9 @@ const isComponentClass = (ComponentClass: any): boolean =>
     )
 
 export const withEffects = <P, E, CP = P>(
-    handler: Handler<P, E>,
-    errorHandler?: ErrorHandler<P>
-) => (aperture: Aperture<P, E>) => (
+    aperture: Aperture<P, E>,
+    config: Partial<Config<P, E>> = {}
+) => (
     BaseComponent: ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentClass<P> =>
     class WithEffects extends Component<P, State> {
@@ -49,7 +54,7 @@ export const withEffects = <P, E, CP = P>(
         constructor(props: any, context: any) {
             super(props, context)
 
-            configureComponent(handler, errorHandler)(
+            configureComponent(config.handler, config.errorHandler)(
                 aperture,
                 this,
                 isValidElement,

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -54,11 +54,13 @@ export const withEffects = <P, E, CP = P>(
         constructor(props: any, context: any) {
             super(props, context)
 
-            configureComponent(config.handler, config.errorHandler)(
+            configureComponent(
                 aperture,
                 this,
                 isValidElement,
-                isComponentClass
+                isComponentClass,
+                config.handler,
+                config.errorHandler
             )
         }
 

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -14,8 +14,8 @@ export interface State {
 }
 
 export interface Config<P, E> {
-    handler: Handler<P, E>
-    errorHandler: ErrorHandler<P, E>
+    handler?: Handler<P, E>
+    errorHandler?: ErrorHandler<P, E>
 }
 
 const Empty = () => null
@@ -37,7 +37,7 @@ const isComponentClass = (ComponentClass: any): boolean =>
 
 export const withEffects = <P, E, CP = P>(
     aperture: Aperture<P, E>,
-    config: Partial<Config<P, E>> = {}
+    config: Config<P, E> = {}
 ) => (
     BaseComponent: ComponentType<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentClass<P> =>

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -12,6 +12,11 @@ export interface State {
     children: VNode | null
 }
 
+export interface Config<P, E> {
+    handler: Handler<P, E, any>
+    errorHandler: ErrorHandler<P, any>
+}
+
 const Empty = () => null
 
 const isValidElement = (value: any): boolean =>
@@ -30,9 +35,9 @@ const isComponentClass = (ComponentClass: any): boolean =>
     )
 
 export const withEffects = <P, E, CP = P>(
-    handler: Handler<P, E>,
-    errorHandler?: ErrorHandler<P>
-) => (aperture: Aperture<P, E>) => (
+    aperture: Aperture<P, E>,
+    config: Partial<Config<P, E>> = {}
+) => (
     BaseComponent: ComponentFactory<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentFactory<P> =>
     class WithEffects extends Component<P, State> {
@@ -48,7 +53,7 @@ export const withEffects = <P, E, CP = P>(
         constructor(props: P) {
             super(props)
 
-            configureComponent(handler, errorHandler)(
+            configureComponent(config.handler, config.errorHandler)(
                 aperture,
                 this,
                 isValidElement,

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -53,11 +53,13 @@ export const withEffects = <P, E, CP = P>(
         constructor(props: P) {
             super(props)
 
-            configureComponent(config.handler, config.errorHandler)(
+            configureComponent(
                 aperture,
                 this,
                 isValidElement,
-                isComponentClass
+                isComponentClass,
+                config.handler,
+                config.errorHandler
             )
         }
 

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -13,8 +13,8 @@ export interface State {
 }
 
 export interface Config<P, E> {
-    handler: Handler<P, E, any>
-    errorHandler: ErrorHandler<P, any>
+    handler?: Handler<P, E, any>
+    errorHandler?: ErrorHandler<P, any>
 }
 
 const Empty = () => null
@@ -36,7 +36,7 @@ const isComponentClass = (ComponentClass: any): boolean =>
 
 export const withEffects = <P, E, CP = P>(
     aperture: Aperture<P, E>,
-    config: Partial<Config<P, E>> = {}
+    config: Config<P, E> = {}
 ) => (
     BaseComponent: ComponentFactory<CP & { pushEvent: PushEvent }> = Empty
 ): ComponentFactory<P> =>

--- a/docs/api/compose.md
+++ b/docs/api/compose.md
@@ -24,6 +24,6 @@ import { withEffects, compose } from 'refract-rxjs'
 
 const WrappedComponent = compose(
     connect(mapStateToProps, mapDispatchToProps),
-    withEffects(handler)(aperture)
+    withEffects(aperture)
 )(BaseComponent)
 ```

--- a/docs/api/withEffects.md
+++ b/docs/api/withEffects.md
@@ -10,17 +10,25 @@ Used to enhance a plain component, wrapping it in a WithEffects component which 
 
 ```js
 withEffects = (
-    handler,
-    errorHandler?,
-    Context?
-) => aperture => BaseComponent => {
+    aperture,
+    { handler?, errorHandler?, Context? }
+) => BaseComponent => {
     return WrappedComponent
 }
 ```
 
 ## Arguments
 
-1.  `handler` _(function)_: a function which causes side-effects in response to `effect` values.
+1.  `aperture` _(function)_: a function which observes data sources within your app, passes this data through any necessary logic flows, and outputs a stream of `effect` values in response.
+
+    Signature: `(initialProps, initialContext) => (component) => { return effectStream }`.
+
+    *   The `initialProps` are all props passed into the `WrappedComponent`.
+    *   The `initialContext` is the initial context value of the provided `Context` (see above, React >= 16.6.0 only)
+    *   The `component` is an object which lets you observe your React, Inferno or Preact component: see [Observing React](../usage/observing-react.md)
+    *   Within the body of the function, you observe the event source you choose, pipe the events through your stream library of choice, and return a single stream of effects.
+
+1.  `handler` _(function)_: an _optional_ function which causes side-effects in response to `effect` values.
 
     Signature: `(initialProps, initialContext) => (effect) => { /* handle effect here */ }`
 
@@ -40,15 +48,6 @@ withEffects = (
 
 1.  `Context` _(ReactContext)_: a React Context object. Its initial value will be passed to `handler`, `errorHandler` and `aperture` (React 16.6.0 and above only).
 
-1.  `aperture` _(function)_: a function which observes data sources within your app, passes this data through any necessary logic flows, and outputs a stream of `effect` values in response.
-
-    Signature: `(initialProps, initialContext) => (component) => { return effectStream }`.
-
-    *   The `initialProps` are all props passed into the `WrappedComponent`.
-    *   The `initialContext` is the initial context value of the provided `Context` (see above, React >= 16.6.0 only)
-    *   The `component` is an object which lets you observe your React, Inferno or Preact component: see [Observing React](../usage/observing-react.md)
-    *   Within the body of the function, you observe the event source you choose, pipe the events through your stream library of choice, and return a single stream of effects.
-
 1.  `BaseComponent` _(React component)_: any react component.
 
 ## Returns
@@ -64,7 +63,7 @@ const BaseComponent = ({ username, onChange }) => (
     <input value={username} onChange={onChange} />
 )
 
-const aperture = initialProps => component => {
+const aperture = component => {
     return component.observe('username').pipe(
         debounce(2000),
         map(username => ({
@@ -83,7 +82,7 @@ const handler = initialProps => effect => {
     }
 }
 
-const WrappedComponent = withEffects(handler)(aperture)(BaseComponent)
+const WrappedComponent = withEffects(aperture, { handler })(BaseComponent)
 ```
 
 ## Tips

--- a/docs/api/withEffects.md
+++ b/docs/api/withEffects.md
@@ -11,7 +11,7 @@ Used to enhance a plain component, wrapping it in a WithEffects component which 
 ```js
 withEffects = (
     aperture,
-    { handler?, errorHandler?, Context? }
+    config: { handler?, errorHandler?, Context? }
 ) => BaseComponent => {
     return WrappedComponent
 }
@@ -21,16 +21,16 @@ withEffects = (
 
 1.  `aperture` _(function)_: a function which observes data sources within your app, passes this data through any necessary logic flows, and outputs a stream of `effect` values in response.
 
-    Signature: `(initialProps, initialContext) => (component) => { return effectStream }`.
+    Signature: `(component, initialProps, initialContext?) => { return effectStream }`.
 
+    *   The `component` is an object which lets you observe your React, Inferno or Preact component: see [Observing React](../usage/observing-react.md)
     *   The `initialProps` are all props passed into the `WrappedComponent`.
     *   The `initialContext` is the initial context value of the provided `Context` (see above, React >= 16.6.0 only)
-    *   The `component` is an object which lets you observe your React, Inferno or Preact component: see [Observing React](../usage/observing-react.md)
     *   Within the body of the function, you observe the event source you choose, pipe the events through your stream library of choice, and return a single stream of effects.
 
 1.  `handler` _(function)_: an _optional_ function which causes side-effects in response to `effect` values.
 
-    Signature: `(initialProps, initialContext) => (effect) => { /* handle effect here */ }`
+    Signature: `(initialProps, initialContext?) => (effect) => { /* handle effect here */ }`
 
     *   The `initialProps` are all props passed into the `WrappedComponent`.
     *   The `initialContext` is the initial context value of the provided `Context` (see below, React >= 16.6.0 only)
@@ -39,7 +39,7 @@ withEffects = (
 
 1.  `errorHandler` _(function)_: an _optional_ function for catching any unexpected errors thrown within your `aperture`. Typically used for logging errors.
 
-    Signature: `(initialProps, initialContext) => (error) => { /* handle error here */ }`
+    Signature: `(initialProps, initialContext?) => (error) => { /* handle error here */ }`
 
     *   The `initialProps` are all props passed into the `WrappedComponent`.
     *   The `initialContext` is the initial context value of the provided `Context` (see below, React >= 16.6.0 only)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -9,9 +9,11 @@ A `side-effect` is a general term in computer science. In the context of an app,
 An `aperture` controls the streams of data which enter Refract.
 
 ```js
-type Aperture<P, E> = (
-    initialProps: P
-) => (component: ObservableComponent) => Observable<E>
+type Aperture<P, E, C> = (
+    component: ObservableComponent,
+    initialProps: P,
+    initialContext: C
+) => Observable<E>
 ```
 
 It is a function which observes data sources within your app, passes this data through any necessary logic flows, and outputs a stream of `effect` values in response.
@@ -27,7 +29,7 @@ It's expected that for most applications, `effect`s will likely be plain JavaScr
 A `handler` causes side-effects in response to any `effect` value output by the `aperture`.
 
 ```js
-type Handler<P, E> = (initialProps: P) => (effect: E) => void
+type Handler<P, E> = (initialProps: P, initialContext: C) => (effect: E) => void
 ```
 
 It is a function which imperatively calls any side-effect you wish to result from the output of your aperture. This often includes returning data to your app's flow (via `setState` or Redux `dispatch` for example), but could also include external side-effects which do not loop back into your app (such as localstorage or analytics).
@@ -37,7 +39,10 @@ It is a function which imperatively calls any side-effect you wish to result fro
 An `errorHandler` causes side-effects in response to any fatal error occurring within your `aperture`.
 
 ```js
-type ErrorHandler<P> = (initialProps: P) => (error: any) => void
+type ErrorHandler<P> = (
+    initialProps: P,
+    initialContext: C
+) => (error: any) => void
 ```
 
 It is a function which calls any side-effect you wish to result from any fatal errors within your streams. In some situations, an error can occur which breaks your stream pipeline. In this case, the error is handled by your `errorHandler`. Usually, you would be expected to log this error for further investigation.

--- a/docs/recipes/creating-an-api-dependency.md
+++ b/docs/recipes/creating-an-api-dependency.md
@@ -23,7 +23,7 @@ fetch(`https://api.github.com/users/${username}`)
 When using fetch inside an aperture, there's actually a little extra boilerplate needed, and even worse it makes our aperture impure:
 
 ```js
-const aperture = () => component =>
+const aperture = component =>
     component.observe('username').pipe(
         mergeMap(username =>
             fromPromise(
@@ -40,7 +40,7 @@ The error catching logic is also problematic. If we take the approach shown abov
 Alternatively, we could introduce even more boilerplate and handle errors directly in the stream:
 
 ```js
-const aperture = () => component =>
+const aperture = component =>
     component
         .observe('username')
         .pipe(
@@ -93,7 +93,7 @@ ReactDOM.render(<App api={apiDependency} />)
 This dependency could then be exposed to Refract, allowing it to be called inside the apertures like so:
 
 ```js
-const aperture = ({ api }) => component =>
+const aperture = (component, { api }) =>
     component
         .observe('username')
         .pipe(mergeMap(username => api.getUser(username)))

--- a/docs/recipes/dependency-injection.md
+++ b/docs/recipes/dependency-injection.md
@@ -43,9 +43,11 @@ import { withEffects } from 'refract-rxjs'
 
 const MyComponent = props => <Foo {...props} />
 
-export default withEffects(handler, errorHandler, Context)(aperture)(
-    MyComponent
-)
+export default withEffects(aperture, {
+    handler,
+    errorHandler,
+    Context
+})(MyComponent)
 ```
 
 `handler`, `errorHandler` and `aperture` will then be called with two arguments:
@@ -62,7 +64,7 @@ import { withEffects } from 'refract-rxjs'
 
 const MyComponent = props => <Foo {...props} />
 
-export default withEffects(handler)(aperture)(MyComponent)
+export default withEffects(aperture, { handler })(MyComponent)
 ```
 
 ```js
@@ -95,7 +97,7 @@ import RefractContext from './refractContext'
 const MyComponent = props => <Foo {...props} />
 
 export default contextToProps(RefractContext.Consumer)(
-    withEffects(handler)(aperture)(MyComponent)
+    withEffects(aperture, { handler })(MyComponent)
 )
 ```
 
@@ -116,10 +118,10 @@ import { contextToProps } from 'react-zap'
 
 const RefractContext = createContext()
 
-const enhancedWithEffects = (handler, errorHandler) => aperture => BaseComponent =>
+const enhancedWithEffects = (aperture, { handler, errorHandler }) => BaseComponent =>
     compose(
         contextToProps(RefractContext.Consumer),
-        withEffects(handler, errorHandler)(aperture)
+        withEffects(aperture, { handler, errorHandler })
     )(BaseComponent)
 
 export {
@@ -135,5 +137,5 @@ import { withEffects } from './sideEffects'
 
 const MyComponent = props => <Foo {...props} />
 
-export default withEffects(handler)(aperture)(MyComponent) // now includes dependencies!
+export default withEffects(aperture, { handler })(MyComponent) // now includes dependencies!
 ```

--- a/docs/recipes/handling-state.md
+++ b/docs/recipes/handling-state.md
@@ -40,9 +40,7 @@ import { withEffects, toProps } from 'refract-rxjs'
 import { scan, map } from 'rxjs/operators'
 import Toggle from './Toggle'
 
-const handler = () => () => {}
-
-const aperture = initialProps => component => {
+const aperture = component => {
     const [toggleEvents$, toggle] = component.useEvent('toggle')
 
     return toggleEvents$.pipe(
@@ -60,7 +58,7 @@ const aperture = initialProps => component => {
     )
 }
 
-const ToggleWithState = withEffects(handler)(aperture)(Toggle)
+const ToggleWithState = withEffects(aperture)(Toggle)
 
 export default ToggleWithState
 ```
@@ -79,8 +77,7 @@ import { scan, map } from 'rxjs/operators'
 
 const { Provider, Consumer: CounterStateConsumer } = React.createContext({})
 
-const handler = () => () => {}
-const aperture = initialProps => component => {
+const aperture = (component, initialProps) => {
     const children$ = component.observe('children')
 
     const [countEvents$, countUp] = component.useEvent('count')
@@ -104,7 +101,7 @@ const aperture = initialProps => component => {
     )
 }
 
-const CounterStateProvider = withEffects(handler)(aperture)()
+const CounterStateProvider = withEffects(aperture)()
 
 export { CounterStateProvider, CounterStateConsumer }
 ```

--- a/docs/recipes/handling-state.md
+++ b/docs/recipes/handling-state.md
@@ -40,7 +40,7 @@ import { withEffects, toProps } from 'refract-rxjs'
 import { scan, map } from 'rxjs/operators'
 import Toggle from './Toggle'
 
-const hander = () => () => {}
+const handler = () => () => {}
 
 const aperture = initialProps => component => {
     const [toggleEvents$, toggle] = component.useEvent('toggle')

--- a/docs/recipes/replacing-connect.md
+++ b/docs/recipes/replacing-connect.md
@@ -22,9 +22,7 @@ import { map } from 'rxjs/operators'
 import { withEffects, toProps } from 'refract-rxjs'
 import { getUser, getPosts } from './mySelectors'
 
-const handler = () => () => {}
-
-const aperture = initialProps => component => {
+const aperture = (component, initialProps) => {
     const { store } = initialProps
 
     const user$ = store.observe(getUser)
@@ -39,7 +37,7 @@ const aperture = initialProps => component => {
     )
 }
 
-const ContainerComponent = withEffects(handler)(aperture)(BaseComponent)
+const ContainerComponent = withEffects(aperture)(BaseComponent)
 ```
 
 Let's look at the example above step by step:
@@ -91,7 +89,7 @@ const toDispatch = action => ({
     payload: action
 })
 
-const aperture = initialProps => component => {
+const aperture = component => {
     const [ addPostEvents$, addPost] = component.pushEvent('addPost')
     const [ removePostEvents$, removePost] = component.pushEvent('removePost')
 
@@ -108,7 +106,7 @@ const aperture = initialProps => component => {
     })
 }
 
-const ContainerComponent = withEffects(handler)(aperture)(BaseComponent)
+const ContainerComponent = withEffects(aperture, { handler })(BaseComponent)
 ```
 
 Again, it is a more verbose approach than `mapDispatchToProps`. But by separating action creation from dispatching logic, it enables you to hook other side-effects that you could otherwise find in a Redux middleware (like analytics events).

--- a/docs/usage/connecting-to-react.md
+++ b/docs/usage/connecting-to-react.md
@@ -29,11 +29,11 @@ import { withEffects } from 'refract-rxjs'
 
 // Note that the handler and aperture are explained later in the docs,
 // these empty functions are just placeholders
-const aperture = initialProps => component => {}
+const aperture = (component, initialProps) => {}
 const handler = initialProps => effect => {}
 //
 
-const CounterWithEffects = withEffects(handler)(aperture)(Counter)
+const CounterWithEffects = withEffects(aperture), { handler }(Counter)
 ```
 
 This new `CounterWithEffects` component now includes the side-effect logic included in our `handler` and `aperture`, and renders the original `Counter` presentational component unaltered. It can be used just like any other component:

--- a/docs/usage/injecting-dependencies.md
+++ b/docs/usage/injecting-dependencies.md
@@ -18,7 +18,7 @@ import configureStore from './configureStore'
 import App from './components/App'
 
 const store = configureStore()
-const AppWithEffects = withEffects(handler)(aperture)(App)
+const AppWithEffects = withEffects(aperture, { handler })(App)
 
 ReactDOM.render(
     <Provider store={store}>

--- a/docs/usage/observing-anything.md
+++ b/docs/usage/observing-anything.md
@@ -11,7 +11,7 @@ By using your streaming library's utilities aimed at creating observables, you c
 For example, you can observe the `window.popstate` event to respond to the user clicking back/forward in the browser:
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const popstate$ = fromEvent(window, 'popstate').pipe(
         map(event => ({
             type: 'POPSTATE',
@@ -24,10 +24,8 @@ const aperture = initialProps => component => {
 Or as another example, you could listen to the `window.resize` event in order to dynamically alter your logic depending on the user's screen size:
 
 ```js
-const aperture = initialProps => component => {
-    const resize$ = fromEvent(window, 'resize').pipe(
-        debounce(500)        
-    )
+const aperture = component => {
+    const resize$ = fromEvent(window, 'resize').pipe(debounce(500))
 }
 ```
 
@@ -38,7 +36,7 @@ Your streaming library will also provide utilities for observing the passing of 
 For example, if you want to do something once every few seconds as a kind of background process, it's easy to create an interval stream:
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const interval$ = interval(4000) // emits once every four seconds
 }
 ```

--- a/docs/usage/observing-react.md
+++ b/docs/usage/observing-react.md
@@ -5,7 +5,7 @@
 Refract exposes an object called `component` as your `aperture`'s second argument, which allows you to cause side-effects in response to changes within your React app.
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     /* ... */
 }
 ```
@@ -21,7 +21,7 @@ const Input = ({ value, onChange }) => (
     <input value={value} onChange={onChange} />
 )
 
-const InputWithEffects = withEffects(handler)(aperture)(Input)
+const InputWithEffects = withEffects(aperture, { handler })(Input)
 
 class Container extends Component {
     state = { currentvalue: '' }
@@ -52,7 +52,7 @@ Refract's `component.observe` function lets you observe your React props. It han
 *   `propTransformer` _(function)_: an optional function to transform each received value of `propName`
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const onChange$ = component.observe('onChange')
     const value$ = component.observe('value')
     /* create effects here */
@@ -72,7 +72,7 @@ Refract emits new prop values only if they have changed. The change detection is
 For example, if we want to observe the `value` prop in our aperture, and only cause an effect when the new string is at least five characters long:
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const value$ = component.observe('value')
 
     return value$.pipe(filter(string => string.length > 5))
@@ -94,7 +94,7 @@ When the prop you observe is a function, `component.observe` will return a strea
 For example, if we want to observe arguments passed to the `onChange` prop to achieve the same effect as above:
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const onChange$ = component.observe('onChange')
 
     return onChange$.pipe(filter(string => string.length > 5))
@@ -119,7 +119,7 @@ Instead, when you do not specify a `propName`, `component.observe` will return a
 For example, if you wanted to just send all props through to your `handler` every time one of them changes:
 
 ```js
-const aperture = initialProps => component => component.observe()
+const aperture = component => component.observe()
 ```
 
 ## Observing Events
@@ -146,7 +146,7 @@ In your aperture, you can observe events by simply invoking `component.fromEvent
 *   `eventTransformer` _(function)_: an optional function to transform the value of each `eventName` event
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const buttonClick$ = component.fromEvent('buttonClick')
 
     return buttonClick$.pipe(mapTo('Button clicked!'))
@@ -161,7 +161,7 @@ A convenient helper function `useEvent` is available on `component`, to make it 
 *   `seedValue` _(any)_: an optional seed value to initialise the streem of event values with
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const [ value$, setValue ] = component.useEvent('eventName', '')
 
     return value$.pipe(map(value => toProps({
@@ -183,7 +183,7 @@ These are streams which emit an event, like a signal, either when the component 
 It can be useful to defer any logic until a component has been mounted.
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const mount$ = component.mount
 
     return mount$.pipe(mapTo('Component mounted!'))
@@ -197,7 +197,7 @@ const aperture = initialProps => component => {
 It can be useful to trigger side-effects when a component is about to be unmounted.
 
 ```js
-const aperture = initialProps => component => {
+const aperture = component => {
     const unmount$ = component.unmount
 
     return unmount$.pipe(mapTo('Component unmounted!'))

--- a/docs/usage/observing-redux.md
+++ b/docs/usage/observing-redux.md
@@ -5,7 +5,7 @@ _Before you can observe your Redux store, make sure you have used dependency inj
 Refract adds a method to your store called `observe` (see [Getting Started](./getting-started.md)), which you can use to observe Redux from inside your `aperture`.
 
 ```js
-const aperture = initialProps => component => {
+const aperture = (component, initialProps) => {
     const streamFromStore$ = initialProps.store.observe('something')
 }
 ```
@@ -17,7 +17,7 @@ const aperture = initialProps => component => {
 If you pass in a string, `store.observe` returns a stream of actions dispatched to your store which have that string as their action type.
 
 ```js
-const aperture = ({ store }) => component => {
+const aperture = (component, { store }) => {
     const ping$ = store.observe('PING')
     const pong$ = store.observe('PONG')
 }
@@ -43,7 +43,7 @@ const storeShape = {
 
 const getBalance = username => state => state.users[username].balance
 
-const aperture = ({ store }) => component => {
+const aperture = (component, { store }) => {
     const balance$ = store.observe(getBalance('SomeUserName'))
 }
 ```
@@ -53,7 +53,7 @@ In this example, `balance$` will receive a new value every time the user's balan
 Note that this is particularly powerful in combination with curried selectors - by tweaking the above example to use the `initialProps` to source the username, we can select the slice of state dynamically:
 
 ```js
-const aperture = ({ store, username }) => component => {
+const aperture = (component, { store, username }) => {
     const balance$ = store.observe(getBalance(username))
 }
 ```

--- a/docs/usage/pushing-to-props.md
+++ b/docs/usage/pushing-to-props.md
@@ -26,15 +26,13 @@ const DoubleValue = ({ value, doubledValue }) => (
     <div>Two times {value} is {doubledValue}</button>
 )
 
-const aperture = ({ initialCount }) => component => {
+const aperture = (component, { initialCount }) => {
     component.observe('value').pipe(map(value => toProps({
         doubledValue: 2 * value
     })))
 }
 
-const handler = () => () => {}
-
-export default withEffects(handler)(aperture)(DoubleValue)
+export default withEffects(aperture)(DoubleValue)
 ```
 
 ## Replacing Props
@@ -60,7 +58,7 @@ import { scan, map } from 'rxjs/operators'
 
 const Counter = ({ count, addOne }) => <button onClick={addOne}>{count}</button>
 
-const aperture = ({ initialCount }) => component => {
+const aperture = (component, { initialCount }) => {
     const [addOneEvents$, addOne] = component.useEvent('addOne')
 
     return addOneEvents$.pipe(
@@ -78,7 +76,5 @@ const aperture = ({ initialCount }) => component => {
     )
 }
 
-const handler = () => () => {}
-
-export default withEffects(handler)(aperture)(Counter)
+export default withEffects(aperture)(Counter)
 ```

--- a/docs/usage/rendering-components.md
+++ b/docs/usage/rendering-components.md
@@ -22,7 +22,7 @@ import { scan, map } from 'rxjs/operators'
 
 const Counter = ({ count, addOne }) => <button onClick={addOne}>{count}</button>
 
-const aperture = ({ initialCount }) => component => {
+const aperture = (component, { initialCount }) => {
     const [addOneEvents$, addOne] = component.useEvent('addOne')
 
     return addOneEvents$.pipe(
@@ -40,7 +40,5 @@ const aperture = ({ initialCount }) => component => {
     )
 }
 
-const handler = () => () => {}
-
-export default withEffects(handler)(aperture)()
+export default withEffects(aperture)()
 ```


### PR DESCRIPTION
Flatten withEffects and aperture APIs to allow for optional effect handlers.

```js
withEffects(aperture, { hander, errorHandler, Context })

const aperture = (component, initialProps, initialContext) => {}
```

This is a breaking change, and versions will be bumped to v3.0.0

**Advantages**
- More compact syntax
- Less closures (if that matters)
- Handler can be optional
- Easier access to `component` in Aperture (initialProps and initialContext can be ignored)

**TODO**
- [x] Update code
- [x] Update tests
- [x] Update docs

Examples will be updated once released.