### PR TITLE
Allow useEvent to be value-less (TypeScript)

### DIFF
--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -28,7 +28,7 @@ export const aperture: Aperture<Props, Effect> = component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const [linkClick$, clickLink] = component.useEvent<any>('linkClick', '')
+    const [linkClick$, clickLink] = component.useEvent('linkClick')
 
     return pipe(
         merge(

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -26,7 +26,7 @@ export const aperture: Aperture<Props, Effect> = component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const [linkClick$, clickLink] = component.useEvent<any>('linkClick')
+    const [linkClick$, clickLink] = component.useEvent('linkClick')
 
     return merge<Effect>(
         value$.map(value => ({

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -28,7 +28,7 @@ export const aperture: Aperture<Props, Effect> = component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const [linkClick$, clickLink] = component.useEvent<any>('linkClick')
+    const [linkClick$, clickLink] = component.useEvent('linkClick')
 
     return merge<Effect>(
         value$.pipe(

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -26,7 +26,7 @@ export const aperture: Aperture<Props, Effect> = component => {
     const valueSet$ = component.observe<number>('setValue')
     const mount$ = component.mount
     const unmount$ = component.unmount
-    const [linkClick$, clickLink] = component.useEvent<any>('linkClick')
+    const [linkClick$, clickLink] = component.useEvent('linkClick')
 
     return xs.merge<Effect>(
         value$.map(value => ({

--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -8,4 +8,7 @@ export type ErrorHandler<P, C = any> = (
     initialContext?: C
 ) => (error: any) => void
 
-export type PushEvent = (eventName: string) => <T>(val: T) => void
+export interface PushEvent {
+    (eventName: string): () => void
+    <T = any>(eventName: string): (val: T) => void
+}

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -185,8 +185,8 @@ const configureComponent = <P, E, Ctx>(
         if (state.replace === false) {
             return {
                 ...instance.props,
-                ...stateProps,
-                ...additionalProps
+                ...additionalProps,
+                ...stateProps
             }
         }
 

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -88,7 +88,7 @@ const configureComponent = <P, E, Ctx>(
         listeners = listeners.filter(l => l !== listener)
     }
 
-    const pushEvent: PushEvent = (eventName: string) => <T>(val: T) => {
+    const pushEvent = (eventName: string) => (val?: any) => {
         listeners.forEach(listener => {
             listener.next(createEventData(eventName, val))
         })
@@ -130,7 +130,7 @@ const configureComponent = <P, E, Ctx>(
     const component: ObservableComponent = createComponent(
         propName => instance.props[propName],
         dataObservable,
-        pushEvent
+        pushEvent as PushEvent
     )
 
     const sinkObservable = aperture(component, instance.props, instance.context)
@@ -161,11 +161,11 @@ const configureComponent = <P, E, Ctx>(
     }
 
     instance.triggerMount = () => {
-        pushEvent(MOUNT_EVENT)(undefined)
+        ;(pushEvent as PushEvent)(MOUNT_EVENT)()
     }
 
     instance.triggerUnmount = () => {
-        pushEvent(UNMOUNT_EVENT)(undefined)
+        ;(pushEvent as PushEvent)(UNMOUNT_EVENT)()
         sinkSubscription.unsubscribe()
     }
 

--- a/base/react/configureHook.ts
+++ b/base/react/configureHook.ts
@@ -51,7 +51,7 @@ export const configureHook = <D, E>(
         listeners = listeners.filter(l => l !== listener)
     }
 
-    const pushEvent: PushEvent = (eventName: string) => <T>(val: T) => {
+    const pushEvent = (eventName: string) => (val?: any) => {
         listeners.forEach(listener => {
             listener.next(createEventData(eventName, val))
         })
@@ -73,7 +73,7 @@ export const configureHook = <D, E>(
     const component: ObservableComponent = createComponent(
         propName => data[propName],
         dataObservable,
-        pushEvent
+        pushEvent as PushEvent
     )
 
     const sinkObservable = aperture(component, data)
@@ -85,11 +85,11 @@ export const configureHook = <D, E>(
     )
 
     const pushMountEvent = () => {
-        pushEvent(MOUNT_EVENT)(undefined)
+        ;(pushEvent as PushEvent)(MOUNT_EVENT)()
     }
 
     const pushUnmountEvent = () => {
-        pushEvent(UNMOUNT_EVENT)(undefined)
+        ;(pushEvent as PushEvent)(UNMOUNT_EVENT)()
     }
 
     return {

--- a/base/react/index.ts
+++ b/base/react/index.ts
@@ -3,7 +3,8 @@ import {
     ObservableComponent,
     Aperture,
     ObservableComponentBase,
-    UseEvent
+    UseEvent,
+    FromEvent
 } from './observable'
 import { ErrorHandler, Handler, PushEvent } from './baseTypes'
 import { compose, Compose } from './compose'
@@ -25,6 +26,7 @@ export {
     Handler,
     ErrorHandler,
     PushEvent,
+    FromEvent,
     UseEvent,
     compose,
     Compose,

--- a/base/react/index.ts
+++ b/base/react/index.ts
@@ -2,7 +2,8 @@ import { withEffects } from './withEffects'
 import {
     ObservableComponent,
     Aperture,
-    ObservableComponentBase
+    ObservableComponentBase,
+    UseEvent
 } from './observable'
 import { ErrorHandler, Handler, PushEvent } from './baseTypes'
 import { compose, Compose } from './compose'
@@ -24,6 +25,7 @@ export {
     Handler,
     ErrorHandler,
     PushEvent,
+    UseEvent,
     compose,
     Compose,
     asProps,

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -11,7 +11,7 @@ import {
     distinctUntilChanged,
     startWith
 } from 'rxjs/operators'
-import { PushEvent, Handler, ErrorHandler } from './baseTypes'
+import { PushEvent } from './baseTypes'
 import {
     isEvent,
     MOUNT_EVENT,
@@ -35,13 +35,15 @@ export interface UseEvent {
     ]
 }
 
+export interface FromEvent {
+    (eventName: string): Observable<void>
+    <T>(eventName: string, valueTransformer?: (val: any) => T): Observable<T>
+}
+
 export interface ObservableComponentBase {
     mount: Observable<any>
     unmount: Observable<any>
-    fromEvent: <T>(
-        eventName: string,
-        valueTransformer?: (val: any) => T
-    ) => Observable<T>
+    fromEvent: FromEvent
     pushEvent: PushEvent
     useEvent: UseEvent
 }

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -87,14 +87,15 @@ const getComponentBase = (
             })
         )
 
-    const useEvent = (eventName: string, seedValue?: any) => {
+    const useEvent = (...args) => {
+        const eventName: string = args[0]
+        const hasSeedValue = args.length > 1
+        const seedValue = args[2]
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 
         return [
-            seedValue === undefined
-                ? events$
-                : events$.pipe(startWith(seedValue)),
+            !hasSeedValue ? events$ : events$.pipe(startWith(seedValue)),
             pushEventValue
         ]
     }

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -90,14 +90,15 @@ const getComponentBase = (
             })
         )
 
-    const useEvent = (eventName: string, seedValue?: any) => {
+    const useEvent = (...args) => {
+        const eventName: string = args[0]
+        const hasSeedValue = args.length > 1
+        const seedValue = args[2]
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 
         return [
-            seedValue === undefined
-                ? events$
-                : pipe(events$, startWith(seedValue)),
+            !hasSeedValue ? events$ : pipe(events$, startWith(seedValue)),
             pushEventValue
         ]
     }

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -45,10 +45,7 @@ export interface FromEvent {
 export interface ObservableComponentBase {
     mount: Source<any>
     unmount: Source<any>
-    fromEvent: <T>(
-        eventName: string,
-        valueTransformer?: (val: any) => T
-    ) => Source<T>
+    fromEvent: FromEvent
     pushEvent: PushEvent
     useEvent: UseEvent
 }
@@ -82,7 +79,7 @@ const getComponentBase = (
     data: Source<any>,
     pushEvent: PushEvent
 ): ObservableComponentBase => {
-    const fromEvent = <T>(eventName, valueTransformer?) =>
+    const fromEvent = (eventName, valueTransformer?) =>
         pipe(
             data,
             filter(isEvent(eventName)),

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -37,6 +37,11 @@ export interface UseEvent {
     <T = any>(eventName: string, seedValue?: T): [Source<T>, (val: T) => any]
 }
 
+export interface FromEvent {
+    (eventName: string): Source<void>
+    <T>(eventName: string, valueTransformer?: (val: any) => T): Source<T>
+}
+
 export interface ObservableComponentBase {
     mount: Source<any>
     unmount: Source<any>

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -74,12 +74,15 @@ const getComponentBase = (
             return valueTransformer ? valueTransformer(value) : value
         })
 
-    const useEvent = (eventName: string, seedValue?: any) => {
+    const useEvent = (...args) => {
+        const eventName: string = args[0]
+        const hasSeedValue = args.length > 1
+        const seedValue = args[2]
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 
         return [
-            seedValue === undefined ? events$ : events$.startWith(seedValue),
+            !hasSeedValue ? events$ : events$.startWith(seedValue),
             pushEventValue
         ]
     }

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -20,6 +20,11 @@ export interface UseEvent {
     <T = any>(eventName: string, seedValue?: T): [Stream<T>, (val: T) => any]
 }
 
+export interface FromEvent {
+    (eventName: string): Stream<void>
+    <T>(eventName: string, valueTransformer?: (val: any) => T): Stream<T>
+}
+
 export interface ObservableComponentBase {
     mount: Stream<any>
     unmount: Stream<any>

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -28,10 +28,7 @@ export interface FromEvent {
 export interface ObservableComponentBase {
     mount: Stream<any>
     unmount: Stream<any>
-    fromEvent: <T>(
-        eventName: string,
-        valueTransformer?: (val: any) => T
-    ) => Stream<T>
+    fromEvent: FromEvent
     pushEvent: PushEvent
     useEvent: UseEvent
 }
@@ -70,7 +67,7 @@ const getComponentBase = (
     data: Stream<any>,
     pushEvent: PushEvent
 ): ObservableComponentBase => {
-    const fromEvent = <T>(eventName, valueTransformer?) =>
+    const fromEvent = (eventName, valueTransformer?) =>
         data.filter(isEvent(eventName)).map((data: EventData) => {
             const { value } = data.payload
 

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -21,6 +21,11 @@ export interface UseEvent {
     <T = any>(eventName: string, seedValue?: T): [Stream<T>, (val: T) => any]
 }
 
+export interface FromEvent {
+    (eventName: string): Stream<void>
+    <T>(eventName: string, valueTransformer?: (val: any) => T): Stream<T>
+}
+
 export interface ObservableComponentBase {
     mount: Stream<any>
     unmount: Stream<any>

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -29,15 +29,9 @@ export interface FromEvent {
 export interface ObservableComponentBase {
     mount: Stream<any>
     unmount: Stream<any>
-    fromEvent: <T>(
-        eventName: string,
-        valueTransformer?: (val: any) => T
-    ) => Stream<T>
+    fromEvent: FromEvent
     pushEvent: PushEvent
-    useEvent: <T>(
-        eventName: string,
-        seedValue?: T
-    ) => [Stream<T>, (val: T) => any]
+    useEvent: UseEvent
 }
 
 export interface Observe {
@@ -70,7 +64,7 @@ const getComponentBase = (
     data: Stream<any>,
     pushEvent: PushEvent
 ): ObservableComponentBase => {
-    const fromEvent = <T>(eventName, valueTransformer?) =>
+    const fromEvent = (eventName, valueTransformer?) =>
         data.filter(isEvent(eventName)).map((data: EventData) => {
             const { value } = data.payload
 

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -71,12 +71,15 @@ const getComponentBase = (
             return valueTransformer ? valueTransformer(value) : value
         })
 
-    const useEvent = (eventName: string, seedValue?: any) => {
+    const useEvent = (...args) => {
+        const eventName: string = args[0]
+        const hasSeedValue = args.length > 1
+        const seedValue = args[2]
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 
         return [
-            seedValue === undefined ? events$ : events$.startWith(seedValue),
+            hasSeedValue ? events$ : events$.startWith(seedValue),
             pushEventValue
         ]
     }


### PR DESCRIPTION
- Add function overloads to `useEvent` so that it can be used for value-less events (void)
- Update `fromEvent` and `pushEvent` to also deal with no values