### PR TITLE
Remove side effect of Symbol.observable being polyfilled

### DIFF
--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,4 +1,3 @@
-import $$observable from 'symbol-observable'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { PROPS_EFFECT } from './effects'
 import {
@@ -14,6 +13,7 @@ import {
     createEventData,
     createPropsData,
     createCallbackData,
+    createObservable,
     MOUNT_EVENT,
     UNMOUNT_EVENT
 } from './data'
@@ -117,18 +117,13 @@ const configureComponent = <P, E, Ctx>(
         })
     }
 
-    const dataObservable = {
-        subscribe(listener: Listener<any>) {
-            addListener(listener)
+    const dataObservable = createObservable((listener: Listener<any>) => {
+        addListener(listener)
 
-            listener.next(createPropsData(instance.props))
+        listener.next(createPropsData(instance.props))
 
-            return { unsubscribe: () => removeListener(listener) }
-        },
-        [$$observable]() {
-            return this
-        }
-    }
+        return { unsubscribe: () => removeListener(listener) }
+    })
 
     const component: ObservableComponent = createComponent(
         propName => instance.props[propName],

--- a/base/react/configureHook.ts
+++ b/base/react/configureHook.ts
@@ -1,4 +1,3 @@
-import $$observable from 'symbol-observable'
 import { COMPONENT_EFFECT } from './effects'
 import {
     Listener,
@@ -12,7 +11,8 @@ import {
     createEventData,
     MOUNT_EVENT,
     UNMOUNT_EVENT,
-    createPropsData
+    createPropsData,
+    createObservable
 } from './data'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 
@@ -57,18 +57,13 @@ export const configureHook = <D, E>(
         })
     }
 
-    const dataObservable = {
-        subscribe(listener: Listener<any>) {
-            addListener(listener)
+    const dataObservable = createObservable((listener: Listener<any>) => {
+        addListener(listener)
 
-            listener.next(createPropsData(lastData))
+        listener.next(createPropsData(lastData))
 
-            return { unsubscribe: () => removeListener(listener) }
-        },
-        [$$observable]() {
-            return this
-        }
-    }
+        return { unsubscribe: () => removeListener(listener) }
+    })
 
     const component: ObservableComponent = createComponent(
         propName => data[propName],

--- a/base/react/data.ts
+++ b/base/react/data.ts
@@ -68,3 +68,20 @@ export const shallowEquals = (left, right) =>
     left === right ||
     (Object.keys(left).length === Object.keys(right).length &&
         Object.keys(left).every(leftKey => left[leftKey] === right[leftKey]))
+
+export const createObservable = subscribe => {
+    const observable = {
+        subscribe,
+        ['@@observable']() {
+            return this
+        }
+    }
+
+    // @ts-ignore
+    if (typeof Symbol === 'function' && Symbol.observable) {
+        // @ts-ignore
+        observable[Symbol.observable] = () => observable
+    }
+
+    return observable
+}

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -1,4 +1,3 @@
-import $$observable from 'symbol-observable'
 import { Callbag, Source, Sink } from 'callbag'
 const fromObs = require('callbag-from-obs')
 const toObs = require('callbag-to-obs')

--- a/base/redux/baseTypes.ts
+++ b/base/redux/baseTypes.ts
@@ -8,3 +8,20 @@ export type AddActionListener = (
     listener: ActionListener
 ) => UnsubscribeFn
 export type Selector<T> = (state: object) => T
+
+export const createObservable = subscribe => {
+    const observable = {
+        subscribe,
+        ['@@observable']() {
+            return this
+        }
+    }
+
+    // @ts-ignore
+    if (typeof Symbol === 'function' && Symbol.observable) {
+        // @ts-ignore
+        observable[Symbol.observable] = () => observable
+    }
+
+    return observable
+}

--- a/base/redux/observable_callbag.ts
+++ b/base/redux/observable_callbag.ts
@@ -1,11 +1,10 @@
-import $$observable from 'symbol-observable'
 import { Callbag, Source, Sink } from 'callbag'
 const fromObs = require('callbag-from-obs')
 const dropRepeats = require('callbag-drop-repeats')
 const map = require('callbag-map')
 const pipe = require('callbag-pipe')
 
-import { Selector } from './baseTypes'
+import { Selector, createObservable } from './baseTypes'
 
 export interface ObserveFn {
     <T>(actionTypeOrListener: string | Selector<T>): Source<T>
@@ -20,19 +19,16 @@ export interface Listener<T> {
 export const observeFactory = (store): ObserveFn => {
     return <T>(actionOrSelector: string | Selector<T>): Source<T> => {
         if (typeof actionOrSelector === 'string') {
-            return fromObs({
-                subscribe(listener: Listener<T>) {
+            return fromObs(
+                createObservable((listener: Listener<T>) => {
                     const unsubscribe = store.addActionListener(
                         actionOrSelector,
                         listener.next.bind(listener)
                     )
 
                     return { unsubscribe }
-                },
-                [$$observable]() {
-                    return this
-                }
-            })
+                })
+            )
         }
 
         if (typeof actionOrSelector === 'function') {

--- a/base/redux/observable_most.ts
+++ b/base/redux/observable_most.ts
@@ -1,6 +1,5 @@
 import { from, Stream, Subscriber as Listener, of } from 'most'
-import $$observable from 'symbol-observable'
-import { Selector } from './baseTypes'
+import { Selector, createObservable } from './baseTypes'
 
 export interface ObserveFn {
     <T>(actionTypeOrListener: string | Selector<T>): Stream<T>
@@ -9,19 +8,16 @@ export interface ObserveFn {
 export const observeFactory = (store): ObserveFn => {
     return <T>(actionOrSelector: string | Selector<T>): Stream<T> => {
         if (typeof actionOrSelector === 'string') {
-            return from({
-                subscribe(listener: Listener<T>) {
+            return from(
+                createObservable((listener: Listener<T>) => {
                     const unsubscribe = store.addActionListener(
                         actionOrSelector,
                         listener.next.bind(listener)
                     )
 
                     return { unsubscribe }
-                },
-                [$$observable]() {
-                    return this
-                }
-            })
+                })
+            )
         }
 
         if (typeof actionOrSelector === 'function') {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "rollup-plugin-typescript2": "~0.15.1",
         "rxjs": "~6.1.0",
         "rxjs-compat": "~6.1.0",
-        "symbol-observable": "~1.2.0",
         "tar": "~4.4.6",
         "ts-jest": "~22.4.5",
         "tslint": "~5.10.0",

--- a/packages.js
+++ b/packages.js
@@ -27,22 +27,12 @@ const peerDependencies = {
     }
 }
 const baseDependencies = {
-    react: {
-        'symbol-observable': '~1.2.0'
-    },
-    inferno: {
-        'symbol-observable': '~1.2.0'
-    },
-    preact: {
-        'symbol-observable': '~1.2.0'
-    },
+    react: {},
+    inferno: {},
+    preact: {},
     callbag: {
         callbag: '~1.1.0',
-        'callbag-from-obs': '~1.2.0',
-        'symbol-observable': '~1.2.0'
-    },
-    most: {
-        'symbol-observable': '~1.2.0'
+        'callbag-from-obs': '~1.2.0'
     }
 }
 

--- a/packages/refract-callbag/package.json
+++ b/packages/refract-callbag/package.json
@@ -19,8 +19,7 @@
         "callbag-map": "~1.0.1",
         "callbag-pipe": "~1.1.1",
         "callbag-start-with": "~3.1.0",
-        "callbag-to-obs": "~1.0.0",
-        "symbol-observable": "~1.2.0"
+        "callbag-to-obs": "~1.0.0"
     },
     "keywords": [
         "functional",

--- a/packages/refract-inferno-callbag/package.json
+++ b/packages/refract-inferno-callbag/package.json
@@ -20,8 +20,7 @@
         "callbag-map": "~1.0.1",
         "callbag-pipe": "~1.1.1",
         "callbag-start-with": "~3.1.0",
-        "callbag-to-obs": "~1.0.0",
-        "symbol-observable": "~1.2.0"
+        "callbag-to-obs": "~1.0.0"
     },
     "keywords": [
         "functional",

--- a/packages/refract-inferno-most/package.json
+++ b/packages/refract-inferno-most/package.json
@@ -13,9 +13,6 @@
         "inferno-create-element": "^5.0.0",
         "most": "^1.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-inferno-rxjs/package.json
+++ b/packages/refract-inferno-rxjs/package.json
@@ -13,9 +13,6 @@
         "inferno-create-element": "^5.0.0",
         "rxjs": "^6.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-inferno-xstream/package.json
+++ b/packages/refract-inferno-xstream/package.json
@@ -13,9 +13,6 @@
         "inferno-create-element": "^5.0.0",
         "xstream": ">= 11.3.0 < 12.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-most/package.json
+++ b/packages/refract-most/package.json
@@ -12,9 +12,6 @@
         "most": "^1.0.0",
         "react": ">= 15.0.0 < 17.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-preact-callbag/package.json
+++ b/packages/refract-preact-callbag/package.json
@@ -19,8 +19,7 @@
         "callbag-map": "~1.0.1",
         "callbag-pipe": "~1.1.1",
         "callbag-start-with": "~3.1.0",
-        "callbag-to-obs": "~1.0.0",
-        "symbol-observable": "~1.2.0"
+        "callbag-to-obs": "~1.0.0"
     },
     "keywords": [
         "functional",

--- a/packages/refract-preact-most/package.json
+++ b/packages/refract-preact-most/package.json
@@ -12,9 +12,6 @@
         "most": "^1.0.0",
         "preact": "^8.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-preact-rxjs/package.json
+++ b/packages/refract-preact-rxjs/package.json
@@ -12,9 +12,6 @@
         "preact": "^8.0.0",
         "rxjs": "^6.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-preact-xstream/package.json
+++ b/packages/refract-preact-xstream/package.json
@@ -12,9 +12,6 @@
         "preact": "^8.0.0",
         "xstream": ">= 11.3.0 < 12.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-redux-callbag/package.json
+++ b/packages/refract-redux-callbag/package.json
@@ -16,8 +16,7 @@
         "callbag-drop-repeats": "~1.0.0",
         "callbag-from-obs": "~1.2.0",
         "callbag-map": "~1.0.1",
-        "callbag-pipe": "~1.1.1",
-        "symbol-observable": "~1.2.0"
+        "callbag-pipe": "~1.1.1"
     },
     "keywords": [
         "functional",

--- a/packages/refract-redux-most/package.json
+++ b/packages/refract-redux-most/package.json
@@ -12,9 +12,6 @@
         "most": "^1.0.0",
         "redux": ">= 3.5.0 < 5.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-rxjs/package.json
+++ b/packages/refract-rxjs/package.json
@@ -27,8 +27,5 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org",
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    }
+    "homepage": "https://refract.js.org"
 }

--- a/packages/refract-xstream/package.json
+++ b/packages/refract-xstream/package.json
@@ -27,8 +27,5 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org",
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    }
+    "homepage": "https://refract.js.org"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ export default packages
         )
         const externalDependencies = dependencies.concat(peerDependencies)
 
-        return Object.keys(formats).map(format => ({
+        return {
             input: `${packageDir}/src/index.ts`,
             plugins: [
                 typescript({
@@ -28,11 +28,11 @@ export default packages
                 })
             ],
             external: externalDependencies,
-            output: {
+            output: Object.keys(formats).map(format => ({
                 name: 'refract',
                 format,
                 file: `${packageDir}/${formats[format]}`
-            }
-        }))
+            }))
+        }
     })
-    .reduce((rollupConfig, configs) => rollupConfig.concat(configs, []))
+    .reduce((rollupConfig, configs) => rollupConfig.concat(configs), [])

--- a/yarn.lock
+++ b/yarn.lock
@@ -5407,7 +5407,7 @@ symbol-observable@1.0.1:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
-symbol-observable@1.2.0, symbol-observable@^1.0.2, symbol-observable@^1.2.0, symbol-observable@~1.2.0:
+symbol-observable@1.2.0, symbol-observable@^1.0.2, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==


### PR DESCRIPTION
Remove use of `symbol-observable` package, which has a side-effect of polyfilling `Symbol.observable`. In practice it can lead to errors dependending on `rxjs` being imported before `refract-rxjs` (example).

Each observable is instead earmarked with `'@@observable'` AND `Symbol.observable` (if available).

This approach might cause issues with xstream, which polyfills before using: I'm going to test this further.