### PR TITLE
Remove symbol-observable from rxjs packages + hook fix

### DIFF
--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,4 +1,3 @@
-import $$observable from 'symbol-observable'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 import { PROPS_EFFECT } from './effects'
 import {
@@ -7,7 +6,8 @@ import {
     createComponent,
     ObservableComponent,
     subscribeToSink,
-    Aperture
+    Aperture,
+    createObservable
 } from './observable'
 import {
     shallowEquals,
@@ -117,18 +117,13 @@ const configureComponent = <P, E, Ctx>(
         })
     }
 
-    const dataObservable = {
-        subscribe(listener: Listener<any>) {
-            addListener(listener)
+    const dataObservable = createObservable((listener: Listener<any>) => {
+        addListener(listener)
 
-            listener.next(createPropsData(instance.props))
+        listener.next(createPropsData(instance.props))
 
-            return { unsubscribe: () => removeListener(listener) }
-        },
-        [$$observable]() {
-            return this
-        }
-    }
+        return { unsubscribe: () => removeListener(listener) }
+    })
 
     const component: ObservableComponent = createComponent(
         propName => instance.props[propName],

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -109,6 +109,21 @@ const getComponentBase = (
     }
 }
 
+export const createObservable = subscribe => {
+    const observable = {
+        subscribe,
+        ['@@observable']() {
+            return this
+        }
+    }
+    // @ts-ignore
+    if (typeof Symbol === 'function' && Symbol.observable) {
+        // @ts-ignore
+        observable[Symbol.observable] = () => observable
+    }
+    return observable
+}
+
 export const getObserve = <P>(getProp, data, decoratedProps) => {
     return function observe<T>(propName?, valueTransformer?) {
         if (

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -169,3 +169,10 @@ export const createComponent = <P>(
         ...getComponentBase(data(), pushEvent)
     }
 }
+
+export const createObservable = subscribe => ({
+    subscribe,
+    [$$observable]() {
+        return this
+    }
+})

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -1,3 +1,4 @@
+import $$observable from 'symbol-observable'
 import { from, Stream, Subscriber as Listener } from 'most'
 import { PushEvent } from './baseTypes'
 import {
@@ -142,3 +143,10 @@ export const createComponent = <P>(
         ...getComponentBase(data(), pushEvent)
     }
 }
+
+export const createObservable = subscribe => ({
+    subscribe,
+    [$$observable]() {
+        return this
+    }
+})

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -1,3 +1,5 @@
+import $$observable from 'symbol-observable'
+
 import xs, { Stream, Listener, Subscription } from 'xstream'
 import dropRepeats from 'xstream/extra/dropRepeats'
 import { PushEvent } from './baseTypes'
@@ -139,3 +141,10 @@ export const createComponent = <P>(
         ...getComponentBase(data(), pushEvent)
     }
 }
+
+export const createObservable = subscribe => ({
+    subscribe,
+    [$$observable]() {
+        return this
+    }
+})

--- a/base/react/refractHook.ts
+++ b/base/react/refractHook.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { useState, useLayoutEffect, useEffect } from 'react'
+import { useState, useLayoutEffect, useEffect, useMemo } from 'react'
 import { configureHook } from './configureHook'
 import { Aperture } from './observable'
 import { Handler, ErrorHandler } from './baseTypes'
@@ -14,9 +14,18 @@ export const useRefract = <D, CD = any, E = any>(
     data: D,
     config: Config<D, E> = {}
 ): CD => {
-    const [hook, setData] = useState(
-        configureHook<D, E>(aperture, data, config.handler, config.errorHandler)
+    const initialHook = useMemo(
+        () =>
+            configureHook<D, E>(
+                aperture,
+                data,
+                config.handler,
+                config.errorHandler
+            ),
+        []
     )
+
+    const [hook, setData] = useState(initialHook)
 
     useLayoutEffect(() => {
         hook.registerSetData(setData)
@@ -25,9 +34,12 @@ export const useRefract = <D, CD = any, E = any>(
         return () => hook.unsubscribe()
     }, [])
 
-    useEffect(() => {
-        hook.pushData(data)
-    })
+    useEffect(
+        () => {
+            hook.pushData(data)
+        },
+        [data]
+    )
 
     return hook.data as CD
 }

--- a/base/redux/observable_most.ts
+++ b/base/redux/observable_most.ts
@@ -1,4 +1,4 @@
-import { from, Stream, Subscriber as Listener, of } from 'most'
+import { from, Stream, Subscriber as Listener } from 'most'
 import $$observable from 'symbol-observable'
 import { Selector } from './baseTypes'
 

--- a/packages.js
+++ b/packages.js
@@ -27,15 +27,6 @@ const peerDependencies = {
     }
 }
 const baseDependencies = {
-    react: {
-        'symbol-observable': '~1.2.0'
-    },
-    inferno: {
-        'symbol-observable': '~1.2.0'
-    },
-    preact: {
-        'symbol-observable': '~1.2.0'
-    },
     callbag: {
         callbag: '~1.1.0',
         'callbag-from-obs': '~1.2.0',
@@ -63,6 +54,15 @@ const extraDependencies = {
         'callbag-drop-repeats': '~1.0.0',
         'callbag-map': '~1.0.1',
         'callbag-pipe': '~1.1.1'
+    },
+    'refract-xstream': {
+        'symbol-observable': '~1.2.0'
+    },
+    'refract-inferno-xstream': {
+        'symbol-observable': '~1.2.0'
+    },
+    'refract-preact-xstream': {
+        'symbol-observable': '~1.2.0'
     }
 }
 

--- a/packages/refract-inferno-rxjs/package.json
+++ b/packages/refract-inferno-rxjs/package.json
@@ -13,9 +13,6 @@
         "inferno-create-element": "^5.0.0",
         "rxjs": "^6.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-preact-rxjs/package.json
+++ b/packages/refract-preact-rxjs/package.json
@@ -12,9 +12,6 @@
         "preact": "^8.0.0",
         "rxjs": "^6.0.0"
     },
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    },
     "keywords": [
         "functional",
         "reactive",

--- a/packages/refract-rxjs/package.json
+++ b/packages/refract-rxjs/package.json
@@ -27,8 +27,5 @@
     "bugs": {
         "url": "https://github.com/fanduel-oss/refract/issues"
     },
-    "homepage": "https://refract.js.org",
-    "dependencies": {
-        "symbol-observable": "~1.2.0"
-    }
+    "homepage": "https://refract.js.org"
 }

--- a/scripts/generatePkg.js
+++ b/scripts/generatePkg.js
@@ -47,13 +47,15 @@ async function generatePackages() {
                     ...existingPackage,
                     ...packageBase,
                     peerDependencies,
-                    ...(Object.keys(dependencies).length
-                        ? { dependencies }
-                        : {}),
+                    dependencies,
                     description: `Refract bindings for ${libs[mainLib]} with ${
                         libs[obsLib]
                     }: harness the power of reactive programming to supercharge your components!`,
                     keywords: packageBase.keywords.concat([mainLib, obsLib])
+                }
+
+                if (Object.keys(finalPackage.dependencies).length === 0) {
+                    delete finalPackage.dependencies
                 }
 
                 await writeFile(


### PR DESCRIPTION
- Remove symbol-observable from rxjs packages: implementation of earmark on observables matches https://github.com/ReactiveX/rxjs/blob/master/src/internal/symbol/observable.ts#L13
- Fix issue with hook apertures re-run on each render

Issue: symbol-observable is side-effectful and order of execution means `Symbol.observable` could be unavailable on RxJS but available on Refract.