### PR TITLE
Fix ObservableComponent::useEvent ignoring seed

### DIFF
--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -87,10 +87,8 @@ const getComponentBase = (
             })
         )
 
-    const useEvent = (...args) => {
-        const eventName: string = args[0]
-        const hasSeedValue = args.length > 1
-        const seedValue = args[2]
+    const useEvent = (eventName: string, seedValue?: any) => {
+        const hasSeedValue = arguments.length > 1
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 

--- a/base/react/observable_callbag.ts
+++ b/base/react/observable_callbag.ts
@@ -90,10 +90,8 @@ const getComponentBase = (
             })
         )
 
-    const useEvent = (...args) => {
-        const eventName: string = args[0]
-        const hasSeedValue = args.length > 1
-        const seedValue = args[2]
+    const useEvent = (eventName: string, seedValue?: any) => {
+        const hasSeedValue = arguments.length > 1
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -75,10 +75,8 @@ const getComponentBase = (
             return valueTransformer ? valueTransformer(value) : value
         })
 
-    const useEvent = (...args) => {
-        const eventName: string = args[0]
-        const hasSeedValue = args.length > 1
-        const seedValue = args[2]
+    const useEvent = (eventName: string, seedValue?: any) => {
+        const hasSeedValue = arguments.length > 1
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -73,10 +73,8 @@ const getComponentBase = (
             return valueTransformer ? valueTransformer(value) : value
         })
 
-    const useEvent = (...args) => {
-        const eventName: string = args[0]
-        const hasSeedValue = args.length > 1
-        const seedValue = args[2]
+    const useEvent = (eventName: string, seedValue?: any) => {
+        const hasSeedValue = arguments.length > 1
         const events$ = fromEvent(eventName)
         const pushEventValue = pushEvent(eventName)
 


### PR DESCRIPTION
ObservableComponent::useEvent checked whether
more than one argument was supplied (correct), but
used the 3rd argument as a seed value instead.
That argument is always undefined when using
Refract according to the docs.

This bug was introduced with commit d24f0f099b2.

This commit changes the function signature back
to the original one of using 2 args, one being
optional. The check for the actual argument count
is then done using the arguments object.