### PR TITLE
Fix initial render

### DIFF
--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -193,7 +193,7 @@ const configureComponent = <P, E, Ctx>(
     instance.havePropsChanged = (newProps, newState) => {
         const { state } = instance
 
-        if (state.renderEffect) {
+        if (state.renderEffect || newState.renderEffect) {
             return state.children !== newState.children
         }
 


### PR DESCRIPTION
When rendering as a side-effect, the first side-effect-render was not visible, but subsequent renders were. Example:

```js
import React from 'react'
import { interval } from 'rxjs'
import { map } from 'rxjs/operators'
import { withEffects, Aperture } from 'refract-rxjs'

const aperture: Aperture<any, any> = (component) =>
    interval(5000).pipe(
        map(val => <div>{val}</div>),
    )

export default withEffects(aperture)(() => <div>initial</div>)
```

This would render `<div>initial</div>` first, then 10 seconds later it would render `<div>1</div>`, then increasing `val` values every 5 seconds. The expected `<div>0</div>` was skipped.

Looks like this is because the `havePropsChanged` function didn't compare `state.children` when `oldState.renderEffect` was false, so `shouldComponentUpdate` was effectively returning `false` until the _second_ side-effect render.

Fixed this by also checking `newState.renderEffect` - tested and this works, and I can't see any other issues this would cause!