### PR TITLE
Make generics readable

### DIFF
--- a/base/react/baseTypes.ts
+++ b/base/react/baseTypes.ts
@@ -1,14 +1,14 @@
-export type Handler<P, E, C = any> = (
-    intialProps: P,
-    initialContext?: C
-) => (val: E) => void
+export type Handler<Props, Effect, Context = any> = (
+    intialProps: Props,
+    initialContext?: Context
+) => (val: Effect) => void
 
-export type ErrorHandler<P, C = any> = (
-    intialProps: P,
-    initialContext?: C
+export type ErrorHandler<Props, Context = any> = (
+    intialProps: Props,
+    initialContext?: Context
 ) => (error: any) => void
 
 export interface PushEvent {
     (eventName: string): () => void
-    <T = any>(eventName: string): (val: T) => void
+    <Event = any>(eventName: string): (val: Event) => void
 }

--- a/base/react/compose.ts
+++ b/base/react/compose.ts
@@ -14,44 +14,46 @@ export const compose: Compose = (...fns) => {
 }
 
 export interface Compose {
-    <R>(...fns: Function[]): (arg: any) => R
-    <A, R>(f: (arg: A) => R): (arg: A) => R
-    <A, B, R>(f: (arg: B) => R, g: (arg: A) => B): (arg: A) => R
-    <A, B, C, R>(f: (arg: C) => R, g: (arg: B) => C, h: (arg: A) => B): (
-        arg: A
-    ) => R
-    <A, B, C, D, R>(
-        f: (arg: D) => R,
+    <Result>(...fns: Function[]): (arg: any) => Result
+    <A, Result>(f: (arg: A) => Result): (arg: A) => Result
+    <A, B, Result>(f: (arg: B) => Result, g: (arg: A) => B): (arg: A) => Result
+    <A, B, C, Result>(
+        f: (arg: C) => Result,
+        g: (arg: B) => C,
+        h: (arg: A) => B
+    ): (arg: A) => Result
+    <A, B, C, D, Result>(
+        f: (arg: D) => Result,
         g: (arg: C) => D,
         h: (arg: B) => C,
         i: (arg: A) => B
-    ): (arg: A) => R
-    <A, B, C, D, E, R>(
-        f: (arg: E) => R,
+    ): (arg: A) => Result
+    <A, B, C, D, E, Result>(
+        f: (arg: E) => Result,
         g: (arg: D) => E,
         h: (arg: C) => D,
         i: (arg: B) => C,
         j: (arg: A) => B
-    ): (arg: A) => R
-    <A, B, C, D, E, F, R>(
-        f: (arg: F) => R,
+    ): (arg: A) => Result
+    <A, B, C, D, E, F, Result>(
+        f: (arg: F) => Result,
         g: (arg: E) => F,
         h: (arg: D) => E,
         i: (arg: C) => D,
         j: (arg: B) => C,
         k: (arg: A) => B
-    ): (arg: A) => R
-    <A, B, C, D, E, F, G, R>(
-        f: (arg: G) => R,
+    ): (arg: A) => Result
+    <A, B, C, D, E, F, G, Result>(
+        f: (arg: G) => Result,
         g: (arg: F) => G,
         h: (arg: E) => F,
         i: (arg: D) => E,
         j: (arg: C) => D,
         k: (arg: B) => C,
         l: (arg: A) => B
-    ): (arg: A) => R
-    <A, B, C, D, E, F, G, H, R>(
-        f: (arg: H) => R,
+    ): (arg: A) => Result
+    <A, B, C, D, E, F, G, H, Result>(
+        f: (arg: H) => Result,
         g: (arg: G) => H,
         h: (arg: F) => G,
         i: (arg: E) => F,
@@ -59,5 +61,5 @@ export interface Compose {
         k: (arg: C) => D,
         l: (arg: B) => C,
         m: (arg: A) => B
-    ): (arg: A) => R
+    ): (arg: A) => Result
 }

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -18,13 +18,13 @@ import {
     UNMOUNT_EVENT
 } from './data'
 
-const configureComponent = <P, E, Ctx>(
-    aperture: Aperture<P, E, Ctx>,
+const configureComponent = <Props, Effect, Context>(
+    aperture: Aperture<Props, Effect, Context>,
     instance: any,
     isValidElement: (val: any) => boolean = () => false,
     isComponentClass: (val: any) => boolean = () => false,
-    handler?: Handler<P, E, Ctx>,
-    errorHandler?: ErrorHandler<P>,
+    handler?: Handler<Props, Effect, Context>,
+    errorHandler?: ErrorHandler<Props>,
     mergeProps?: boolean,
     decorateProps?: boolean
 ) => {
@@ -78,7 +78,7 @@ const configureComponent = <P, E, Ctx>(
         }
     }
 
-    const decoratedProps: Partial<P> = {}
+    const decoratedProps: Partial<Props> = {}
 
     let listeners: Array<Listener<any>> = []
 
@@ -134,7 +134,7 @@ const configureComponent = <P, E, Ctx>(
 
     const sinkObservable = aperture(component, instance.props, instance.context)
 
-    const sinkSubscription: Subscription = subscribeToSink<E>(
+    const sinkSubscription: Subscription = subscribeToSink<Effect>(
         sinkObservable,
         finalHandler(instance.props, instance.context),
         errorHandler
@@ -155,7 +155,7 @@ const configureComponent = <P, E, Ctx>(
         }
     }
 
-    instance.pushProps = (props: P) => {
+    instance.pushProps = (props: Props) => {
         listeners.forEach(listener => {
             listener.next(createPropsData(props))
         })

--- a/base/react/configureHook.ts
+++ b/base/react/configureHook.ts
@@ -16,11 +16,11 @@ import {
 } from './data'
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
 
-export const configureHook = <D, E>(
-    aperture: Aperture<D, E>,
-    data: D,
-    handler: Handler<D, E> = () => () => void 0,
-    errorHandler?: ErrorHandler<D>
+export const configureHook = <Data, Effect>(
+    aperture: Aperture<Data, Effect>,
+    data: Data,
+    handler: Handler<Data, Effect> = () => () => void 0,
+    errorHandler?: ErrorHandler<Data>
 ) => {
     let returnedData
     let lastData = data
@@ -74,7 +74,7 @@ export const configureHook = <D, E>(
 
     const sinkObservable = aperture(component, data)
 
-    const sinkSubscription: Subscription = subscribeToSink<E>(
+    const sinkSubscription: Subscription = subscribeToSink<Effect>(
         sinkObservable,
         finalHandler(data),
         errorHandler ? errorHandler(data) : undefined
@@ -95,7 +95,7 @@ export const configureHook = <D, E>(
             sinkSubscription.unsubscribe()
         },
         pushMountEvent,
-        pushData: (data: D) => {
+        pushData: (data: Data) => {
             lastData = data
 
             listeners.forEach(listener => {

--- a/base/react/data.ts
+++ b/base/react/data.ts
@@ -7,11 +7,11 @@ export enum DataType {
     CALLBACK = 'callback'
 }
 
-export type Data<P> = PropsData<P> | CallbackData | EventData
+export type Data<Props> = PropsData<Props> | CallbackData | EventData
 
-export interface PropsData<P> {
+export interface PropsData<Props> {
     type: DataType
-    payload: Partial<P>
+    payload: Partial<Props>
 }
 
 export interface CallbackData {
@@ -30,13 +30,14 @@ export interface EventData {
     }
 }
 
-export const isEvent = <P>(eventName) => (data: Data<P>, index?) =>
+export const isEvent = <Props>(eventName) => (data: Data<Props>, index?) =>
     data.type === DataType.EVENT &&
     (data as EventData).payload.name === eventName
 
-export const isProps = <P>(data: Data<P>) => data.type === DataType.PROPS
+export const isProps = <Props>(data: Data<Props>) =>
+    data.type === DataType.PROPS
 
-export const isCallback = <P>(propName) => (data: Data<P>) =>
+export const isCallback = <Props>(propName) => (data: Data<Props>) =>
     data.type === DataType.CALLBACK &&
     (data as CallbackData).payload.name === propName
 
@@ -48,7 +49,7 @@ export const createEventData = (name: string, value?: any): EventData => ({
     }
 })
 
-export const createPropsData = <P>(props: P): PropsData<P> => ({
+export const createPropsData = <Props>(props: Props): PropsData<Props> => ({
     type: DataType.PROPS,
     payload: props
 })

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,20 +1,20 @@
 export const PROPS_EFFECT: string = '@@refract/effect/props'
 export const COMPONENT_EFFECT: string = '@@refract/effect/component'
 
-export interface PropEffect<P = object> {
+export interface PropEffect<Props = object> {
     type: string
     payload: {
         replace: boolean
-        props: P
+        props: Props
     }
 }
 
-export interface ComponentEffect<D = object> {
+export interface ComponentEffect<Data = object> {
     type: string
-    payload: D
+    payload: Data
 }
 
-export const toProps = <P>(props: P): PropEffect<P> => ({
+export const toProps = <Props>(props: Props): PropEffect<Props> => ({
     type: PROPS_EFFECT,
     payload: {
         replace: false,
@@ -22,7 +22,7 @@ export const toProps = <P>(props: P): PropEffect<P> => ({
     }
 })
 
-export const asProps = <P>(props: P): PropEffect<P> => ({
+export const asProps = <Props>(props: Props): PropEffect<Props> => ({
     type: PROPS_EFFECT,
     payload: {
         replace: true,
@@ -30,7 +30,7 @@ export const asProps = <P>(props: P): PropEffect<P> => ({
     }
 })
 
-export const toRender = <D>(data: D): ComponentEffect<D> => ({
+export const toRender = <Data>(data: Data): ComponentEffect<Data> => ({
     type: COMPONENT_EFFECT,
     payload: data
 })

--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -29,15 +29,18 @@ export { Listener, Subscription }
 
 export interface UseEvent {
     (eventName: string): [Observable<void>, () => any]
-    <T = any>(eventName: string, seedValue?: T): [
-        Observable<T>,
-        (val: T) => any
+    <Type = any>(eventName: string, seedValue?: Type): [
+        Observable<Type>,
+        (val: Type) => any
     ]
 }
 
 export interface FromEvent {
     (eventName: string): Observable<void>
-    <T>(eventName: string, valueTransformer?: (val: any) => T): Observable<T>
+    <Type>(
+        eventName: string,
+        valueTransformer?: (val: any) => Type
+    ): Observable<Type>
 }
 
 export interface ObservableComponentBase {
@@ -49,23 +52,23 @@ export interface ObservableComponentBase {
 }
 
 export interface Observe {
-    observe: <T>(
+    observe: <Type>(
         propName?: string,
-        valueTransformer?: (val: any) => T
-    ) => Observable<T>
+        valueTransformer?: (val: any) => Type
+    ) => Observable<Type>
 }
 
 export type ObservableComponent = Observe & ObservableComponentBase
 
-export type Aperture<P, E, C = any> = (
+export type Aperture<Props, Effect, Context = any> = (
     component: ObservableComponent,
-    initialProps: P,
-    initialContext?: C
-) => Observable<E>
+    initialProps: Props,
+    initialContext?: Context
+) => Observable<Effect>
 
-export const subscribeToSink = <T>(
-    sink: Observable<T>,
-    next: (val: T) => void,
+export const subscribeToSink = <Type>(
+    sink: Observable<Type>,
+    next: (val: Type) => void,
     error?: (error: any) => void
 ): Subscription =>
     sink.subscribe({
@@ -115,8 +118,8 @@ export const createObservable = subscribe => ({
     }
 })
 
-export const getObserve = <P>(getProp, data, decoratedProps) => {
-    return function observe<T>(propName?, valueTransformer?) {
+export const getObserve = <Props>(getProp, data, decoratedProps) => {
+    return function observe<Type>(propName?, valueTransformer?) {
         if (
             decoratedProps &&
             propName &&
@@ -134,7 +137,7 @@ export const getObserve = <P>(getProp, data, decoratedProps) => {
         if (propName) {
             return data().pipe(
                 filter(isProps),
-                map((data: PropsData<P>) => {
+                map((data: PropsData<Props>) => {
                     const prop = data.payload[propName]
 
                     return valueTransformer ? valueTransformer(prop) : prop
@@ -145,19 +148,19 @@ export const getObserve = <P>(getProp, data, decoratedProps) => {
 
         return data().pipe(
             filter(isProps),
-            map((data: PropsData<P>) => data.payload),
+            map((data: PropsData<Props>) => data.payload),
             distinctUntilChanged(shallowEquals)
         )
     }
 }
 
-export const createComponent = <P>(
+export const createComponent = <Props>(
     getProp,
     dataObservable,
     pushEvent: PushEvent,
     decoratedProps: boolean
 ): ObservableComponent => {
-    const data = () => from<Data<P>>(dataObservable)
+    const data = () => from<Data<Props>>(dataObservable)
 
     return {
         observe: getObserve(getProp, data, decoratedProps),

--- a/base/react/observable_most.ts
+++ b/base/react/observable_most.ts
@@ -18,12 +18,17 @@ export { Listener }
 
 export interface UseEvent {
     (eventName: string): [Stream<void>, () => any]
-    <T = any>(eventName: string, seedValue?: T): [Stream<T>, (val: T) => any]
+    <Type = any>(eventName: string, seedValue?: Type): [
+        Stream<Type>,
+        (val: Type) => any
+    ]
 }
 
 export interface FromEvent {
     (eventName: string): Stream<void>
-    <T>(eventName: string, valueTransformer?: (val: any) => T): Stream<T>
+    <Type>(eventName: string, valueTransformer?: (val: any) => Type): Stream<
+        Type
+    >
 }
 
 export interface ObservableComponentBase {
@@ -35,10 +40,10 @@ export interface ObservableComponentBase {
 }
 
 export interface Observe {
-    observe: <T>(
+    observe: <Type>(
         propName?: string,
-        valueTransformer?: (val: any) => T
-    ) => Stream<T>
+        valueTransformer?: (val: any) => Type
+    ) => Stream<Type>
 }
 
 export type ObservableComponent = Observe & ObservableComponentBase
@@ -47,15 +52,15 @@ export interface Subscription {
     unsubscribe(): void
 }
 
-export type Aperture<P, E, C = any> = (
+export type Aperture<Props, Effect, Context = any> = (
     component: ObservableComponent,
-    initialProps: P,
-    initialContext?: C
-) => Stream<E>
+    initialProps: Props,
+    initialContext?: Context
+) => Stream<Effect>
 
-export const subscribeToSink = <T>(
-    sink: Stream<T>,
-    next: (val: T) => void,
+export const subscribeToSink = <Type>(
+    sink: Stream<Type>,
+    next: (val: Type) => void,
     error?: (error: any) => void
 ): Subscription =>
     sink.subscribe({
@@ -95,8 +100,8 @@ const getComponentBase = (
     }
 }
 
-export const getObserve = <P>(getProp, data, decoratedProps) => {
-    return function observe<T>(propName?, valueTransformer?) {
+export const getObserve = <Props>(getProp, data, decoratedProps) => {
+    return function observe<Type>(propName?, valueTransformer?) {
         if (
             decoratedProps &&
             propName &&
@@ -113,7 +118,7 @@ export const getObserve = <P>(getProp, data, decoratedProps) => {
         if (propName) {
             return data()
                 .filter(isProps)
-                .map((data: PropsData<P>) => {
+                .map((data: PropsData<Props>) => {
                     const prop = data.payload[propName]
 
                     return valueTransformer ? valueTransformer(prop) : prop
@@ -123,18 +128,18 @@ export const getObserve = <P>(getProp, data, decoratedProps) => {
 
         return data()
             .filter(isProps)
-            .map((data: PropsData<P>) => data.payload)
+            .map((data: PropsData<Props>) => data.payload)
             .skipRepeatsWith(shallowEquals)
     }
 }
 
-export const createComponent = <P>(
+export const createComponent = <Props>(
     getProp,
     dataObservable,
     pushEvent: PushEvent,
     decoratedProps: boolean
 ): ObservableComponent => {
-    const data = () => from<Data<P>>(dataObservable)
+    const data = () => from<Data<Props>>(dataObservable)
 
     return {
         observe: getObserve(getProp, data, decoratedProps),

--- a/base/react/observable_xstream.ts
+++ b/base/react/observable_xstream.ts
@@ -20,12 +20,17 @@ export { Listener, Subscription }
 
 export interface UseEvent {
     (eventName: string): [Stream<void>, () => any]
-    <T = any>(eventName: string, seedValue?: T): [Stream<T>, (val: T) => any]
+    <Type = any>(eventName: string, seedValue?: Type): [
+        Stream<Type>,
+        (val: Type) => any
+    ]
 }
 
 export interface FromEvent {
     (eventName: string): Stream<void>
-    <T>(eventName: string, valueTransformer?: (val: any) => T): Stream<T>
+    <Type>(eventName: string, valueTransformer?: (val: any) => Type): Stream<
+        Type
+    >
 }
 
 export interface ObservableComponentBase {
@@ -37,23 +42,23 @@ export interface ObservableComponentBase {
 }
 
 export interface Observe {
-    observe: <T>(
+    observe: <Type>(
         propName?: string,
-        valueTransformer?: (val: any) => T
-    ) => Stream<T>
+        valueTransformer?: (val: any) => Type
+    ) => Stream<Type>
 }
 
 export type ObservableComponent = Observe & ObservableComponentBase
 
-export type Aperture<P, E, C = any> = (
+export type Aperture<Props, Effect, Context = any> = (
     component: ObservableComponent,
-    initialProps: P,
-    initialContext?: C
-) => Stream<E>
+    initialProps: Props,
+    initialContext?: Context
+) => Stream<Effect>
 
-export const subscribeToSink = <T>(
-    sink: Stream<T>,
-    next: (val: T) => void,
+export const subscribeToSink = <Type>(
+    sink: Stream<Type>,
+    next: (val: Type) => void,
     error?: (error: any) => void
 ): Subscription =>
     sink.subscribe({
@@ -93,8 +98,8 @@ const getComponentBase = (
     }
 }
 
-export const getObserve = <P>(getProp, data, decoratedProps) => {
-    return function observe<T>(propName?, valueTransformer?) {
+export const getObserve = <Props>(getProp, data, decoratedProps) => {
+    return function observe<Type>(propName?, valueTransformer?) {
         if (
             decoratedProps &&
             propName &&
@@ -111,7 +116,7 @@ export const getObserve = <P>(getProp, data, decoratedProps) => {
         if (propName) {
             return data()
                 .filter(isProps)
-                .map((data: PropsData<P>) => {
+                .map((data: PropsData<Props>) => {
                     const prop = data.payload[propName]
 
                     return valueTransformer ? valueTransformer(prop) : prop
@@ -121,18 +126,18 @@ export const getObserve = <P>(getProp, data, decoratedProps) => {
 
         return data()
             .filter(isProps)
-            .map((data: PropsData<P>) => data.payload)
+            .map((data: PropsData<Props>) => data.payload)
             .compose(dropRepeats(shallowEquals))
     }
 }
 
-export const createComponent = <P>(
+export const createComponent = <Props>(
     getProp,
     dataObservable,
     pushEvent: PushEvent,
     decoratedProps: boolean
 ): ObservableComponent => {
-    const data = () => xs.from<Data<P>>(dataObservable)
+    const data = () => xs.from<Data<Props>>(dataObservable)
 
     return {
         observe: getObserve(getProp, data, decoratedProps),

--- a/base/react/reactHooks.d.ts
+++ b/base/react/reactHooks.d.ts
@@ -1,27 +1,32 @@
 import * as React from 'react'
 
 declare module 'react' {
-    function useState<T>(
-        initialState: T | (() => T)
-    ): [T, (newState: T) => void]
+    function useState<Type>(
+        initialState: Type | (() => Type)
+    ): [Type, (newState: Type) => void]
     function useEffect(
         create: () => void | (() => void),
         inputs?: ReadonlyArray<unknown>
     ): void
-    function useContext<T>(foo: React.Context<T>): T
-    function useReducer<S, A>(
-        reducer: (state: S, action: A) => S,
-        initialState: S
-    ): [S, (action: A) => void]
-    function useCallback<F extends (...args: never[]) => unknown>(
-        callback: F,
+    function useContext<Type>(foo: React.Context<Type>): Type
+    function useReducer<State, Action>(
+        reducer: (state: State, action: Action) => State,
+        initialState: State
+    ): [State, (action: Action) => void]
+    function useCallback<Callback extends (...args: never[]) => unknown>(
+        callback: Callback,
         inputs?: ReadonlyArray<unknown>
-    ): F
-    function useMemo<T>(create: () => T, inputs?: ReadonlyArray<unknown>): T
-    function useRef<T extends unknown>(initialValue?: T): React.RefObject<T>
-    function useImperativeMethods<T>(
-        ref: React.Ref<T>,
-        createInstance: () => T,
+    ): Callback
+    function useMemo<Type>(
+        create: () => Type,
+        inputs?: ReadonlyArray<unknown>
+    ): Type
+    function useRef<Type extends unknown>(
+        initialValue?: Type
+    ): React.RefObject<Type>
+    function useImperativeMethods<Type>(
+        ref: React.Ref<Type>,
+        createInstance: () => Type,
         inputs?: ReadonlyArray<unknown>
     ): void
     const useMutationEffect: typeof useEffect

--- a/base/react/refractHook.ts
+++ b/base/react/refractHook.ts
@@ -4,19 +4,19 @@ import { configureHook } from './configureHook'
 import { Aperture } from './observable'
 import { Handler, ErrorHandler } from './baseTypes'
 
-export interface Config<D, E> {
-    handler?: Handler<D, E>
-    errorHandler?: ErrorHandler<D>
+export interface Config<Data, Effect> {
+    handler?: Handler<Data, Effect>
+    errorHandler?: ErrorHandler<Data>
 }
 
-export const useRefract = <D, CD = any, E = any>(
-    aperture: Aperture<D, E>,
-    data: D,
-    config: Config<D, E> = {}
-): CD => {
+export const useRefract = <Data, CurrentData = any, Effect = any>(
+    aperture: Aperture<Data, Effect>,
+    data: Data,
+    config: Config<Data, Effect> = {}
+): CurrentData => {
     const initialHook = useMemo(
         () =>
-            configureHook<D, E>(
+            configureHook<Data, Effect>(
                 aperture,
                 data,
                 config.handler,
@@ -41,5 +41,5 @@ export const useRefract = <D, CD = any, E = any>(
         [data]
     )
 
-    return hook.data as CD
+    return hook.data as CurrentData
 }

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -30,12 +30,12 @@ const isComponentClass = (ComponentClass: any): boolean =>
 
 const Empty = () => null
 
-export const withEffects = <Props, Effect, CurrentProps = Props, Context = any>(
+export const withEffects = <Props, Effect, ChildProps = Props, Context = any>(
     aperture: Aperture<Props, Effect, Context>,
     config: Config<Props, Effect, Context> = {}
 ) => (
     BaseComponent: React.ComponentType<
-        CurrentProps & { pushEvent: PushEvent }
+        ChildProps & { pushEvent: PushEvent }
     > = Empty
 ): React.ComponentClass<Props> =>
     class WithEffects extends React.Component<Props, State> {
@@ -49,7 +49,7 @@ export const withEffects = <Props, Effect, CurrentProps = Props, Context = any>(
         ) => boolean
         private reDecorateProps: (nextProps: Props) => void
         private pushProps: (props: Props) => void
-        private getChildProps: () => CurrentProps & { pushEvent: PushEvent }
+        private getChildProps: () => ChildProps & { pushEvent: PushEvent }
         private mounted: boolean = false
         private unmounted: boolean = false
 

--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -13,10 +13,10 @@ export interface State {
     children: React.ReactNode | null
 }
 
-export interface Config<P, E, C = any> {
-    handler?: Handler<P, E, C>
-    errorHandler?: ErrorHandler<P, C>
-    Context?: React.Context<C>
+export interface Config<Props, Effect, Context = any> {
+    handler?: Handler<Props, Effect, Context>
+    errorHandler?: ErrorHandler<Props, Context>
+    Context?: React.Context<Context>
     mergeProps?: boolean
     decorateProps?: boolean
 }
@@ -30,21 +30,26 @@ const isComponentClass = (ComponentClass: any): boolean =>
 
 const Empty = () => null
 
-export const withEffects = <P, E, CP = P, C = any>(
-    aperture: Aperture<P, E, C>,
-    config: Config<P, E, C> = {}
+export const withEffects = <Props, Effect, CurrentProps = Props, Context = any>(
+    aperture: Aperture<Props, Effect, Context>,
+    config: Config<Props, Effect, Context> = {}
 ) => (
-    BaseComponent: React.ComponentType<CP & { pushEvent: PushEvent }> = Empty
-): React.ComponentClass<P> =>
-    class WithEffects extends React.Component<P, State> {
+    BaseComponent: React.ComponentType<
+        CurrentProps & { pushEvent: PushEvent }
+    > = Empty
+): React.ComponentClass<Props> =>
+    class WithEffects extends React.Component<Props, State> {
         public static contextType = config.Context
 
         private triggerMount: () => void
         private triggerUnmount: () => void
-        private havePropsChanged: (nextProps: P, nextState: State) => boolean
-        private reDecorateProps: (nextProps: P) => void
-        private pushProps: (props: P) => void
-        private getChildProps: () => CP & { pushEvent: PushEvent }
+        private havePropsChanged: (
+            nextProps: Props,
+            nextState: State
+        ) => boolean
+        private reDecorateProps: (nextProps: Props) => void
+        private pushProps: (props: Props) => void
+        private getChildProps: () => CurrentProps & { pushEvent: PushEvent }
         private mounted: boolean = false
         private unmounted: boolean = false
 
@@ -68,7 +73,7 @@ export const withEffects = <P, E, CP = P, C = any>(
             this.triggerMount()
         }
 
-        public componentWillReceiveProps(nextProps: P) {
+        public componentWillReceiveProps(nextProps: Props) {
             this.reDecorateProps(nextProps)
             this.pushProps(nextProps)
         }

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -37,13 +37,11 @@ const isComponentClass = (ComponentClass: any): boolean =>
             ComponentClass.prototype.componentDidMount
     )
 
-export const withEffects = <Props, Effect, CurrentProps = Props>(
+export const withEffects = <Props, Effect, ChildProps = Props>(
     aperture: Aperture<Props, Effect>,
     config: Config<Props, Effect> = {}
 ) => (
-    BaseComponent: ComponentType<
-        CurrentProps & { pushEvent: PushEvent }
-    > = Empty
+    BaseComponent: ComponentType<ChildProps & { pushEvent: PushEvent }> = Empty
 ): ComponentClass<Props> =>
     class WithEffects extends Component<Props, State> {
         private triggerMount: () => void
@@ -54,7 +52,7 @@ export const withEffects = <Props, Effect, CurrentProps = Props>(
         ) => boolean
         private reDecorateProps: (nextProps: Props) => void
         private pushProps: (props: Props) => void
-        private getChildProps: () => CurrentProps & { pushEvent: PushEvent }
+        private getChildProps: () => ChildProps & { pushEvent: PushEvent }
         private mounted: boolean = false
         private unmounted: boolean = false
 

--- a/base/react/withEffects_inferno.ts
+++ b/base/react/withEffects_inferno.ts
@@ -13,9 +13,9 @@ export interface State {
     children: VNode | null
 }
 
-export interface Config<P, E> {
-    handler?: Handler<P, E>
-    errorHandler?: ErrorHandler<P, E>
+export interface Config<Props, Effect> {
+    handler?: Handler<Props, Effect>
+    errorHandler?: ErrorHandler<Props, Effect>
     mergeProps?: boolean
     decorateProps?: boolean
 }
@@ -37,19 +37,24 @@ const isComponentClass = (ComponentClass: any): boolean =>
             ComponentClass.prototype.componentDidMount
     )
 
-export const withEffects = <P, E, CP = P>(
-    aperture: Aperture<P, E>,
-    config: Config<P, E> = {}
+export const withEffects = <Props, Effect, CurrentProps = Props>(
+    aperture: Aperture<Props, Effect>,
+    config: Config<Props, Effect> = {}
 ) => (
-    BaseComponent: ComponentType<CP & { pushEvent: PushEvent }> = Empty
-): ComponentClass<P> =>
-    class WithEffects extends Component<P, State> {
+    BaseComponent: ComponentType<
+        CurrentProps & { pushEvent: PushEvent }
+    > = Empty
+): ComponentClass<Props> =>
+    class WithEffects extends Component<Props, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
-        private havePropsChanged: (nextProps: P, nextState: State) => boolean
-        private reDecorateProps: (nextProps: P) => void
-        private pushProps: (props: P) => void
-        private getChildProps: () => CP & { pushEvent: PushEvent }
+        private havePropsChanged: (
+            nextProps: Props,
+            nextState: State
+        ) => boolean
+        private reDecorateProps: (nextProps: Props) => void
+        private pushProps: (props: Props) => void
+        private getChildProps: () => CurrentProps & { pushEvent: PushEvent }
         private mounted: boolean = false
         private unmounted: boolean = false
 
@@ -73,7 +78,7 @@ export const withEffects = <P, E, CP = P>(
             this.triggerMount()
         }
 
-        public componentWillReceiveProps(nextProps: P) {
+        public componentWillReceiveProps(nextProps: Props) {
             this.reDecorateProps(nextProps)
             this.pushProps(nextProps)
         }

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -12,9 +12,9 @@ export interface State {
     children: VNode | null
 }
 
-export interface Config<P, E> {
-    handler?: Handler<P, E, any>
-    errorHandler?: ErrorHandler<P, any>
+export interface Config<Props, Effect> {
+    handler?: Handler<Props, Effect, any>
+    errorHandler?: ErrorHandler<Props, any>
     mergeProps?: boolean
     decorateProps?: boolean
 }
@@ -36,23 +36,28 @@ const isComponentClass = (ComponentClass: any): boolean =>
             ComponentClass.prototype.componentDidMount
     )
 
-export const withEffects = <P, E, CP = P>(
-    aperture: Aperture<P, E>,
-    config: Config<P, E> = {}
+export const withEffects = <Props, Effect, CurrentProps = Props>(
+    aperture: Aperture<Props, Effect>,
+    config: Config<Props, Effect> = {}
 ) => (
-    BaseComponent: ComponentFactory<CP & { pushEvent: PushEvent }> = Empty
-): ComponentFactory<P> =>
-    class WithEffects extends Component<P, State> {
+    BaseComponent: ComponentFactory<
+        CurrentProps & { pushEvent: PushEvent }
+    > = Empty
+): ComponentFactory<Props> =>
+    class WithEffects extends Component<Props, State> {
         private triggerMount: () => void
         private triggerUnmount: () => void
-        private havePropsChanged: (nextProps: P, nextState: State) => boolean
-        private reDecorateProps: (nextProps: P) => void
-        private pushProps: (props: P) => void
-        private getChildProps: () => CP & { pushEvent: PushEvent }
+        private havePropsChanged: (
+            nextProps: Props,
+            nextState: State
+        ) => boolean
+        private reDecorateProps: (nextProps: Props) => void
+        private pushProps: (props: Props) => void
+        private getChildProps: () => CurrentProps & { pushEvent: PushEvent }
         private mounted: boolean = false
         private unmounted: boolean = false
 
-        constructor(props: P) {
+        constructor(props: Props) {
             super(props)
 
             configureComponent(

--- a/base/react/withEffects_preact.ts
+++ b/base/react/withEffects_preact.ts
@@ -36,12 +36,12 @@ const isComponentClass = (ComponentClass: any): boolean =>
             ComponentClass.prototype.componentDidMount
     )
 
-export const withEffects = <Props, Effect, CurrentProps = Props>(
+export const withEffects = <Props, Effect, ChildProps = Props>(
     aperture: Aperture<Props, Effect>,
     config: Config<Props, Effect> = {}
 ) => (
     BaseComponent: ComponentFactory<
-        CurrentProps & { pushEvent: PushEvent }
+        ChildProps & { pushEvent: PushEvent }
     > = Empty
 ): ComponentFactory<Props> =>
     class WithEffects extends Component<Props, State> {
@@ -53,7 +53,7 @@ export const withEffects = <Props, Effect, CurrentProps = Props>(
         ) => boolean
         private reDecorateProps: (nextProps: Props) => void
         private pushProps: (props: Props) => void
-        private getChildProps: () => CurrentProps & { pushEvent: PushEvent }
+        private getChildProps: () => ChildProps & { pushEvent: PushEvent }
         private mounted: boolean = false
         private unmounted: boolean = false
 

--- a/base/redux/baseTypes.ts
+++ b/base/redux/baseTypes.ts
@@ -7,4 +7,4 @@ export type AddActionListener = (
     actionType: string,
     listener: ActionListener
 ) => UnsubscribeFn
-export type Selector<T> = (state: object) => T
+export type Selector<Type> = (state: object) => Type

--- a/base/redux/observable.ts
+++ b/base/redux/observable.ts
@@ -4,13 +4,13 @@ import { Selector } from './baseTypes'
 import { Store } from 'redux'
 
 export interface ObserveFn {
-    <T>(actionTypeOrListener: string | Selector<T>): Observable<T>
+    <Type>(actionTypeOrListener: string | Selector<Type>): Observable<Type>
 }
 
 export const observeFactory = (store): ObserveFn => {
-    return <T>(actionOrSelector) => {
+    return <Type>(actionOrSelector) => {
         if (typeof actionOrSelector === 'string') {
-            return Observable.create((listener: Partial<Listener<T>>) => {
+            return Observable.create((listener: Partial<Listener<Type>>) => {
                 const unsubscribe = store.addActionListener(
                     actionOrSelector,
                     listener.next.bind(listener)
@@ -21,9 +21,9 @@ export const observeFactory = (store): ObserveFn => {
         }
 
         if (typeof actionOrSelector === 'function') {
-            return from(store).pipe<T>(
+            return from(store).pipe<Type>(
                 map(actionOrSelector),
-                distinctUntilChanged<T>()
+                distinctUntilChanged<Type>()
             )
         }
     }

--- a/base/redux/observable_callbag.ts
+++ b/base/redux/observable_callbag.ts
@@ -8,20 +8,20 @@ const pipe = require('callbag-pipe')
 import { Selector } from './baseTypes'
 
 export interface ObserveFn {
-    <T>(actionTypeOrListener: string | Selector<T>): Source<T>
+    <Type>(actionTypeOrListener: string | Selector<Type>): Source<Type>
 }
 
-export interface Listener<T> {
-    next: (val: T) => void
+export interface Listener<Type> {
+    next: (val: Type) => void
     error: (err: any) => void
-    complete: (val?: T) => void
+    complete: (val?: Type) => void
 }
 
 export const observeFactory = (store): ObserveFn => {
-    return <T>(actionOrSelector: string | Selector<T>): Source<T> => {
+    return <Type>(actionOrSelector: string | Selector<Type>): Source<Type> => {
         if (typeof actionOrSelector === 'string') {
             return fromObs({
-                subscribe(listener: Listener<T>) {
+                subscribe(listener: Listener<Type>) {
                     const unsubscribe = store.addActionListener(
                         actionOrSelector,
                         listener.next.bind(listener)

--- a/base/redux/observable_most.ts
+++ b/base/redux/observable_most.ts
@@ -3,14 +3,14 @@ import $$observable from 'symbol-observable'
 import { Selector } from './baseTypes'
 
 export interface ObserveFn {
-    <T>(actionTypeOrListener: string | Selector<T>): Stream<T>
+    <Type>(actionTypeOrListener: string | Selector<Type>): Stream<Type>
 }
 
 export const observeFactory = (store): ObserveFn => {
-    return <T>(actionOrSelector: string | Selector<T>): Stream<T> => {
+    return <Type>(actionOrSelector: string | Selector<Type>): Stream<Type> => {
         if (typeof actionOrSelector === 'string') {
             return from({
-                subscribe(listener: Listener<T>) {
+                subscribe(listener: Listener<Type>) {
                     const unsubscribe = store.addActionListener(
                         actionOrSelector,
                         listener.next.bind(listener)

--- a/base/redux/observable_xstream.ts
+++ b/base/redux/observable_xstream.ts
@@ -3,16 +3,16 @@ import dropRepeats from 'xstream/extra/dropRepeats'
 import { Selector } from './baseTypes'
 
 export interface ObserveFn {
-    <T>(actionTypeOrListener: string | Selector<T>): Stream<T>
+    <Type>(actionTypeOrListener: string | Selector<Type>): Stream<Type>
 }
 
 export const observeFactory = (store): ObserveFn => {
-    return <T>(actionOrSelector: string | Selector<T>): Stream<T> => {
+    return <Type>(actionOrSelector: string | Selector<Type>): Stream<Type> => {
         if (typeof actionOrSelector === 'string') {
             let unsubscribe
 
             return xs.create({
-                start(listener: Partial<Listener<T>>) {
+                start(listener: Partial<Listener<Type>>) {
                     unsubscribe = store.addActionListener(
                         actionOrSelector,
                         listener.next.bind(listener)

--- a/base/redux/refractEnhancer.ts
+++ b/base/redux/refractEnhancer.ts
@@ -4,7 +4,7 @@ import {
     StoreCreator,
     Store,
     AnyAction,
-    Action
+    Action as ReduxAction
 } from 'redux'
 
 import { observeFactory, ObserveFn } from './observable'
@@ -26,8 +26,8 @@ const defaultOptions: EnhancerOptions = {
 }
 
 export default function refractStoreEnhancer<
-    S = any,
-    A extends Action<any> = AnyAction
+    State = any,
+    Action extends ReduxAction<any> = AnyAction
 >(options: Partial<EnhancerOptions> = {}): StoreEnhancer {
     const opts: EnhancerOptions = { ...defaultOptions, ...options }
 
@@ -35,7 +35,7 @@ export default function refractStoreEnhancer<
         reducer: Reducer,
         initialState: {},
         enhancer?: StoreEnhancer
-    ): Store<S, A> => {
+    ): Store<State, Action> => {
         const actionListeners: ActionListeners = {}
         const store = createStore(reducer, initialState, enhancer)
         const dispatch = store.dispatch
@@ -78,6 +78,6 @@ export default function refractStoreEnhancer<
 
         store.observe = observeFactory(store)
 
-        return store as Store<S, A>
+        return store as Store<State, Action>
     }
 }


### PR DESCRIPTION
Quickly came to hate the cryptic generic names when using Refract with TS - would be much more readable if they were actual words!