### PR TITLE
Default ContextType to null, to fix React warning

### DIFF
--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -39,7 +39,7 @@ export const withEffects = <Props, Effect, ChildProps = Props, Context = any>(
     > = Empty
 ): React.ComponentClass<Props> =>
     class WithEffects extends React.Component<Props, State> {
-        public static contextType = config.Context
+        public static contextType = config.Context || null
 
         private triggerMount: () => void
         private triggerUnmount: () => void


### PR DESCRIPTION
Fixes #144 

There's a test in the React codebase which confirms that `null` is the correct value to conditionally set a `contextType`:

https://github.com/facebook/react/blob/3f058debc29ccb05a47ac8a8d747c5a5b29a6ed3/packages/react-dom/src/__tests__/ReactServerRendering-test.js#L947-L958