### PR TITLE
Add `methodName` option to redux enhancer

### DIFF
--- a/base/redux/baseTypes.ts
+++ b/base/redux/baseTypes.ts
@@ -1,5 +1,6 @@
 export interface EnhancerOptions {
     eventsPrefix: string
+    methodName: string
 }
 export type ActionListener = (action: object) => void
 export type UnsubscribeFn = () => void

--- a/base/redux/index.ts
+++ b/base/redux/index.ts
@@ -1,5 +1,5 @@
 import refractEnhancer from './refractEnhancer'
 import { EnhancerOptions } from './baseTypes'
-import { ObserveFn } from './observable'
+import { StoreObserveFunction } from './observable'
 
-export { refractEnhancer, EnhancerOptions, ObserveFn }
+export { refractEnhancer, EnhancerOptions, StoreObserveFunction }

--- a/base/redux/index.ts
+++ b/base/redux/index.ts
@@ -1,4 +1,5 @@
 import refractEnhancer from './refractEnhancer'
 import { EnhancerOptions } from './baseTypes'
+import { ObserveFn } from './observable'
 
-export { refractEnhancer, EnhancerOptions }
+export { refractEnhancer, EnhancerOptions, ObserveFn }

--- a/base/redux/observable.ts
+++ b/base/redux/observable.ts
@@ -3,11 +3,11 @@ import { map, distinctUntilChanged } from 'rxjs/operators'
 import { Selector } from './baseTypes'
 import { Store } from 'redux'
 
-export interface ObserveFn {
+export interface StoreObserveFunction {
     <Type>(actionTypeOrListener: string | Selector<Type>): Observable<Type>
 }
 
-export const observeFactory = (store): ObserveFn => {
+export const observeFactory = (store): StoreObserveFunction => {
     return <Type>(actionOrSelector) => {
         if (typeof actionOrSelector === 'string') {
             return Observable.create((listener: Partial<Listener<Type>>) => {

--- a/base/redux/observable_callbag.ts
+++ b/base/redux/observable_callbag.ts
@@ -7,7 +7,7 @@ const pipe = require('callbag-pipe')
 
 import { Selector } from './baseTypes'
 
-export interface ObserveFn {
+export interface StoreObserveFunction {
     <Type>(actionTypeOrListener: string | Selector<Type>): Source<Type>
 }
 
@@ -17,7 +17,7 @@ export interface Listener<Type> {
     complete: (val?: Type) => void
 }
 
-export const observeFactory = (store): ObserveFn => {
+export const observeFactory = (store): StoreObserveFunction => {
     return <Type>(actionOrSelector: string | Selector<Type>): Source<Type> => {
         if (typeof actionOrSelector === 'string') {
             return fromObs({

--- a/base/redux/observable_most.ts
+++ b/base/redux/observable_most.ts
@@ -2,11 +2,11 @@ import { from, Stream, Subscriber as Listener } from 'most'
 import $$observable from 'symbol-observable'
 import { Selector } from './baseTypes'
 
-export interface ObserveFn {
+export interface StoreObserveFunction {
     <Type>(actionTypeOrListener: string | Selector<Type>): Stream<Type>
 }
 
-export const observeFactory = (store): ObserveFn => {
+export const observeFactory = (store): StoreObserveFunction => {
     return <Type>(actionOrSelector: string | Selector<Type>): Stream<Type> => {
         if (typeof actionOrSelector === 'string') {
             return from({

--- a/base/redux/observable_xstream.ts
+++ b/base/redux/observable_xstream.ts
@@ -2,11 +2,11 @@ import xs, { Stream, Listener } from 'xstream'
 import dropRepeats from 'xstream/extra/dropRepeats'
 import { Selector } from './baseTypes'
 
-export interface ObserveFn {
+export interface StoreObserveFunction {
     <Type>(actionTypeOrListener: string | Selector<Type>): Stream<Type>
 }
 
-export const observeFactory = (store): ObserveFn => {
+export const observeFactory = (store): StoreObserveFunction => {
     return <Type>(actionOrSelector: string | Selector<Type>): Stream<Type> => {
         if (typeof actionOrSelector === 'string') {
             let unsubscribe

--- a/base/redux/refractEnhancer.ts
+++ b/base/redux/refractEnhancer.ts
@@ -22,7 +22,8 @@ interface ActionListeners {
 }
 
 const defaultOptions: EnhancerOptions = {
-    eventsPrefix: '@@event/'
+    eventsPrefix: '@@event/',
+    methodName: 'observe'
 }
 
 export default function refractStoreEnhancer<
@@ -76,7 +77,7 @@ export default function refractStoreEnhancer<
             }
         }
 
-        store[opts.methodName || 'observe'] = observeFactory(store)
+        store[opts.methodName] = observeFactory(store)
 
         return store as Store<State, Action>
     }

--- a/base/redux/refractEnhancer.ts
+++ b/base/redux/refractEnhancer.ts
@@ -7,13 +7,13 @@ import {
     Action as ReduxAction
 } from 'redux'
 
-import { observeFactory, ObserveFn } from './observable'
+import { observeFactory, StoreObserveFunction } from './observable'
 import { AddActionListener, ActionListener, EnhancerOptions } from './baseTypes'
 
 declare module 'redux' {
     interface Store {
         addActionListener: AddActionListener
-        observe: ObserveFn
+        observe: StoreObserveFunction
     }
 }
 

--- a/base/redux/refractEnhancer.ts
+++ b/base/redux/refractEnhancer.ts
@@ -76,7 +76,7 @@ export default function refractStoreEnhancer<
             }
         }
 
-        store.observe = observeFactory(store)
+        store[opts.methodName || 'observe'] = observeFactory(store)
 
         return store as Store<State, Action>
     }

--- a/docs/api/refractEnhancer.md
+++ b/docs/api/refractEnhancer.md
@@ -26,11 +26,11 @@ refractEnhancer = (options?) => {
         Note that customising the `methodName` option with TypeScript will break the Redux `Store` interface, which is extended when you import the Refract enhancer. To use this option with TypeScript, you will need to extend the interface - for example:
 
         ```js
-        import { ObserveFn } from 'refract-redux-rxjs'
+        import { StoreObserveFunction } from 'refract-redux-rxjs'
 
         declare module 'redux' {
             interface Store {
-                observeWithRxjs: ObserveFn
+                observeWithRxjs: StoreObserveFunction
             }
         }
         ```

--- a/docs/api/refractEnhancer.md
+++ b/docs/api/refractEnhancer.md
@@ -16,11 +16,12 @@ refractEnhancer = (options?) => {
 
 ## Arguments
 
-1. `options` _(object)_: an object which configures the Refract store enhancer.
+1.  `options` _(object)_: an object which configures the Refract store enhancer.
 
-    Currently, `refractEnhancer` only supports one option:
+    Two options are currently available for the `refractEnhancer`:
 
-    * `eventsPrefix` _(string)_: defines an actionType prefix which marks actions which are _not_ intended to be forwarded to your reducers. Refract will intercept these, preventing them from touching your state, but will forward them on to any watching apertures. (default: `@@event/`)
+    *   `eventsPrefix` _(string)_: defines an actionType prefix which marks actions which are _not_ intended to be forwarded to your reducers. Refract will intercept these, preventing them from touching your state, but will forward them on to any watching apertures. (default: `@@event/`)
+    *   `methodName` _(string)_: customises the name used for the `store.observe` method. (default: `observe`)
 
 ## Returns
 

--- a/docs/api/refractEnhancer.md
+++ b/docs/api/refractEnhancer.md
@@ -23,6 +23,18 @@ refractEnhancer = (options?) => {
     *   `eventsPrefix` _(string)_: defines an actionType prefix which marks actions which are _not_ intended to be forwarded to your reducers. Refract will intercept these, preventing them from touching your state, but will forward them on to any watching apertures. (default: `@@event/`)
     *   `methodName` _(string)_: customises the name used for the `store.observe` method. (default: `observe`)
 
+        Note that customising the `methodName` option with TypeScript will break the Redux `Store` interface, which is extended when you import the Refract enhancer. To use this option with TypeScript, you will need to extend the interface - for example:
+
+        ```js
+        import { ObserveFn } from 'refract-redux-rxjs'
+
+        declare module 'redux' {
+            interface Store {
+                observeWithRxjs: ObserveFn
+            }
+        }
+        ```
+
 ## Returns
 
 `StoreCreator` _(Redux store creator)_: a function which creates a redux store. Note that you should not be calling this function directly, and instead should be passing it into Redux `createStore`.


### PR DESCRIPTION
We're considering migrating from `xstream` to `rxjs`, and one requirement is that we would want to transition incrementally over time.

This is not possible with the current version of `refract-redux`. We would need to use store enhancers for both `refract-redux-xstream` and `refract-redux-rxjs` at the same time during the transition; currently this would result in the `store.observe` method from one enhancer overwriting the one from the other enhancer.

Solution is to add the ability to customise the method name - we would then be able to set the method name to `store.observeRx` for the RxJS version of the enhancer for the duration of the migration, and rename it to `store.observe` once the transition is complete.

Feels a bit weird to add an option just to allow a one-time migration, but it's super simple change to the code, so can't see why not.