### PR TITLE
fixing typo in the example of using withEffects.

### DIFF
--- a/docs/usage/connecting-to-react.md
+++ b/docs/usage/connecting-to-react.md
@@ -33,7 +33,7 @@ const aperture = (component, initialProps) => {}
 const handler = initialProps => effect => {}
 //
 
-const CounterWithEffects = withEffects(aperture), { handler }(Counter)
+const CounterWithEffects = withEffects(aperture, { handler })(Counter)
 ```
 
 This new `CounterWithEffects` component now includes the side-effect logic included in our `handler` and `aperture`, and renders the original `Counter` presentational component unaltered. It can be used just like any other component:


### PR DESCRIPTION
Fixing typo in Connecting to React section. 