### PR TITLE
use UNSAFE_componentWillReceiveProps to avoid warning

### DIFF
--- a/base/react/withEffects.ts
+++ b/base/react/withEffects.ts
@@ -73,7 +73,7 @@ export const withEffects = <Props, Effect, ChildProps = Props, Context = any>(
             this.triggerMount()
         }
 
-        public componentWillReceiveProps(nextProps: Props) {
+        public UNSAFE_componentWillReceiveProps(nextProps: Props) {
             this.reDecorateProps(nextProps)
             this.pushProps(nextProps)
         }


### PR DESCRIPTION
Fixes #154

Temporary fix; we'll need to figure out what the best approach is going forward.