### PR TITLE
Fix mergeProps behaviour

### DIFF
--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -42,6 +42,8 @@ const configureComponent = <Props, Effect, Context>(
 
         if (instance.mounted) {
             instance.setState(state)
+        } else if (typeof state === 'function') {
+            instance.state = state(instance.state)
         } else {
             instance.state = {
                 ...instance.state,
@@ -64,15 +66,20 @@ const configureComponent = <Props, Effect, Context>(
             } else if (effect && effect.type === PROPS_EFFECT) {
                 const { payload } = effect
 
-                setState({
-                    replace: payload.replace,
-                    props: mergeProps
-                        ? {
-                              ...instance.state.props,
-                              ...payload.props
-                          }
-                        : payload.props
-                })
+                if (mergeProps) {
+                    setState(prev => ({
+                        replace: payload.replace,
+                        props: {
+                            ...prev.props,
+                            ...payload.props
+                        }
+                    }))
+                } else {
+                    setState({
+                        replace: payload.replace,
+                        props: payload.props
+                    })
+                }
             } else {
                 effectHandler(effect)
             }


### PR DESCRIPTION
This is a bit of an edge case, but worth fixing I think, since the behaviour is not obvious. If you're using the `mergeProps` option and you push updates too fast, the state will not update as expected.

For example, given the following initial `state.props` and two subsequent updates in the same aperture:

- `{ a: 'a', b: 'b' }`
- `toProps({ a: 'A' })`
- `toProps({ b: 'B' })`

You would expect the resulting `state.props` to be:

- `{ a: 'A', b: 'B' }`

Instead, you get:

- `{ a: 'a', b: 'B' }`

This is because of how React batches state updates, which isn't taken into account when Refract merges props. The lines which cause this issue are:

https://github.com/fanduel-oss/refract/blob/183b296616aec69284bda8ac17ca63b507913bf3/base/react/configureComponent.ts#L67-L75

What's happening is that the second `toProps` effect is being called before React has time to re-render the component. As a result, `instance.state.props` is the same for each update, so the second update includes the stale value for the state slice which is _not_ being updated. Instead we want to queue the updates so that each subsequent state is merged from the previous one.

The way to do this is to pass a state updater function to React's `setState`; this queues the updates instead of batching them, resulting in the behaviour we expect. 🎉