### PR TITLE
Add toCallback

### DIFF
--- a/base/__tests__/inferno/callbag/index.tsx
+++ b/base/__tests__/inferno/callbag/index.tsx
@@ -3,13 +3,14 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-inferno-callbag/src'
 import {
     aperture,
     toPropsAperture,
     asPropsAperture,
+    toCallbackAperture,
     Effect,
     Props,
     ExtraProps,
@@ -212,5 +213,59 @@ describe('refract-inferno-callbag', () => {
         })
 
         expect(node.text()).toBe('hi')
+    })
+
+    describe('toCallback', () => {
+        describe('when the callback prop exists', () => {
+            it('should call the callback', () => {
+                const callback = jest.fn()
+                interface Props {
+                    callback: (message: any) => void
+                }
+                const WithEffects = withEffects<Props, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects callback={callback} />)
+
+                expect(callback).toHaveBeenCalledWith('Hello world!')
+            })
+        })
+
+        describe('when the callback prop does not exist', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<{}, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
+
+        describe('when the prop exists but is not a function', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<
+                    { callback: string },
+                    CallbackEffect<string>
+                    // @ts-ignore
+                >(toCallbackAperture)(() => null)
+
+                mount(<WithEffects callback="string" />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
     })
 })

--- a/base/__tests__/inferno/most/index.tsx
+++ b/base/__tests__/inferno/most/index.tsx
@@ -3,13 +3,14 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-inferno-most/src'
 import {
     aperture,
     toPropsAperture,
     asPropsAperture,
+    toCallbackAperture,
     Effect,
     Props,
     ExtraProps,
@@ -216,5 +217,59 @@ describe('refract-inferno-most', () => {
         })
 
         expect(node.text()).toBe('hi')
+    })
+
+    describe('toCallback', () => {
+        describe('when the callback prop exists', () => {
+            it('should call the callback', () => {
+                const callback = jest.fn()
+                interface Props {
+                    callback: (message: any) => void
+                }
+                const WithEffects = withEffects<Props, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects callback={callback} />)
+
+                expect(callback).toHaveBeenCalledWith('Hello world!')
+            })
+        })
+
+        describe('when the callback prop does not exist', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<{}, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
+
+        describe('when the prop exists but is not a function', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<
+                    { callback: string },
+                    CallbackEffect<string>
+                    // @ts-ignore
+                >(toCallbackAperture)(() => null)
+
+                mount(<WithEffects callback="string" />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
     })
 })

--- a/base/__tests__/inferno/rxjs/index.tsx
+++ b/base/__tests__/inferno/rxjs/index.tsx
@@ -3,13 +3,14 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-inferno-rxjs/src'
 import {
     aperture,
     toPropsAperture,
     asPropsAperture,
+    toCallbackAperture,
     Effect,
     Props,
     ExtraProps,
@@ -212,5 +213,59 @@ describe('refract-inferno-rxjs', () => {
         })
 
         expect(node.text()).toBe('hi')
+    })
+
+    describe('toCallback', () => {
+        describe('when the callback prop exists', () => {
+            it('should call the callback', () => {
+                const callback = jest.fn()
+                interface Props {
+                    callback: (message: any) => void
+                }
+                const WithEffects = withEffects<Props, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects callback={callback} />)
+
+                expect(callback).toHaveBeenCalledWith('Hello world!')
+            })
+        })
+
+        describe('when the callback prop does not exist', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<{}, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
+
+        describe('when the prop exists but is not a function', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<
+                    { callback: string },
+                    CallbackEffect<string>
+                    // @ts-ignore
+                >(toCallbackAperture)(() => null)
+
+                mount(<WithEffects callback="string" />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
     })
 })

--- a/base/__tests__/inferno/xstream/index.tsx
+++ b/base/__tests__/inferno/xstream/index.tsx
@@ -3,13 +3,14 @@ import { createElement } from 'inferno-create-element'
 import {
     withEffects,
     Handler,
-    ObservableComponent,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-inferno-xstream/src'
 import {
     aperture,
     toPropsAperture,
     asPropsAperture,
+    toCallbackAperture,
     Effect,
     Props,
     ExtraProps,
@@ -212,5 +213,59 @@ describe('refract-inferno-xstream', () => {
         })
 
         expect(node.text()).toBe('hi')
+    })
+
+    describe('toCallback', () => {
+        describe('when the callback prop exists', () => {
+            it('should call the callback', () => {
+                const callback = jest.fn()
+                interface Props {
+                    callback: (message: any) => void
+                }
+                const WithEffects = withEffects<Props, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects callback={callback} />)
+
+                expect(callback).toHaveBeenCalledWith('Hello world!')
+            })
+        })
+
+        describe('when the callback prop does not exist', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<{}, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                // @ts-ignore
+                mount(<WithEffects />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
+
+        describe('when the prop exists but is not a function', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<
+                    { callback: string },
+                    CallbackEffect<string>
+                    // @ts-ignore
+                >(toCallbackAperture)(() => null)
+
+                mount(<WithEffects callback="string" />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
     })
 })

--- a/base/__tests__/react/callbag/aperture.ts
+++ b/base/__tests__/react/callbag/aperture.ts
@@ -4,8 +4,10 @@ import of from 'callbag-of'
 
 import {
     Aperture,
+    toCallback,
     toProps,
     asProps,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-callbag/src'
 
@@ -105,3 +107,13 @@ export const createRenderingAperture = <VNode>(
 
     return aperture
 }
+
+export const toCallbackAperture: Aperture<
+    { callback: () => void },
+    CallbackEffect<string>
+> = component =>
+    pipe(
+        component.mount,
+        map(() => 'Hello world!'),
+        map(toCallback('callback'))
+    )

--- a/base/__tests__/react/callbag/index.tsx
+++ b/base/__tests__/react/callbag/index.tsx
@@ -2,13 +2,14 @@ import * as React from 'react'
 import {
     withEffects,
     Handler,
-    ObservableComponent,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-callbag/src'
 import {
     aperture,
     toPropsAperture,
     asPropsAperture,
+    toCallbackAperture,
     Effect,
     Props,
     ExtraProps,
@@ -209,5 +210,57 @@ describe('refract-callbag', () => {
         expect(() => mount(<WithEffects />)).toThrow()
 
         jest.clearAllMocks()
+    })
+
+    describe('toCallback', () => {
+        describe('when the callback prop exists', () => {
+            it('should call the callback', () => {
+                const callback = jest.fn()
+                interface Props {
+                    callback: (message: any) => void
+                }
+                const WithEffects = withEffects<Props, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                mount(<WithEffects callback={callback} />)
+
+                expect(callback).toHaveBeenCalledWith('Hello world!')
+            })
+        })
+
+        describe('when the callback prop does not exist', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<{}, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                mount(<WithEffects />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
+
+        describe('when the prop exists but is not a function', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                // @ts-ignore
+                const WithEffects = withEffects<
+                    { callback: string },
+                    CallbackEffect<string>
+                >(toCallbackAperture)(() => null)
+
+                mount(<WithEffects callback="string" />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
     })
 })

--- a/base/__tests__/react/most/aperture.ts
+++ b/base/__tests__/react/most/aperture.ts
@@ -1,9 +1,11 @@
-import { merge, of, from } from 'most'
+import { merge, of } from 'most'
 
 import {
     Aperture,
+    toCallback,
     toProps,
     asProps,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-most/src'
 
@@ -104,3 +106,9 @@ export const createRenderingAperture = <VNode>(
 
     return aperture
 }
+
+export const toCallbackAperture: Aperture<
+    { callback: () => void },
+    CallbackEffect<string>
+> = component =>
+    component.mount.map(() => 'Hello world!').map(toCallback('callback'))

--- a/base/__tests__/react/most/index.tsx
+++ b/base/__tests__/react/most/index.tsx
@@ -2,13 +2,14 @@ import * as React from 'react'
 import {
     withEffects,
     Handler,
-    ObservableComponent,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-most/src'
 import {
     aperture,
     toPropsAperture,
     asPropsAperture,
+    toCallbackAperture,
     Effect,
     Props,
     ExtraProps,
@@ -212,5 +213,57 @@ describe('refract-most', () => {
         expect(() => mount(<WithEffects />)).toThrow()
 
         jest.clearAllMocks()
+    })
+
+    describe('toCallback', () => {
+        describe('when the callback prop exists', () => {
+            it('should call the callback', () => {
+                const callback = jest.fn()
+                interface Props {
+                    callback: (message: any) => void
+                }
+                const WithEffects = withEffects<Props, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                mount(<WithEffects callback={callback} />)
+
+                expect(callback).toHaveBeenCalledWith('Hello world!')
+            })
+        })
+
+        describe('when the callback prop does not exist', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<{}, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                mount(<WithEffects />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
+
+        describe('when the prop exists but is not a function', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                // @ts-ignore
+                const WithEffects = withEffects<
+                    { callback: string },
+                    CallbackEffect<string>
+                >(toCallbackAperture)(() => null)
+
+                mount(<WithEffects callback="string" />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
     })
 })

--- a/base/__tests__/react/rxjs/aperture.ts
+++ b/base/__tests__/react/rxjs/aperture.ts
@@ -3,8 +3,10 @@ import { merge, of, empty } from 'rxjs'
 
 import {
     Aperture,
+    toCallback,
     toProps,
     asProps,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-rxjs/src'
 
@@ -118,3 +120,9 @@ export const createRenderingAperture = <VNode>(
 }
 
 export const emptyStream = empty
+
+export const toCallbackAperture: Aperture<
+    { callback: () => void },
+    CallbackEffect<string>
+> = component =>
+    component.mount.pipe(map(() => 'Hello world!'), map(toCallback('callback')))

--- a/base/__tests__/react/xstream/aperture.ts
+++ b/base/__tests__/react/xstream/aperture.ts
@@ -1,11 +1,12 @@
 import xs from 'xstream'
 import {
     Aperture,
+    toCallback,
     toProps,
     asProps,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-xstream/src'
-import { of } from 'most'
 
 export interface Effect {
     type: string
@@ -100,3 +101,9 @@ export const createRenderingAperture = <VNode>(
 
     return aperture
 }
+
+export const toCallbackAperture: Aperture<
+    { callback: () => void },
+    CallbackEffect<string>
+> = component =>
+    component.mount.map(() => 'Hello world!').map(toCallback('callback'))

--- a/base/__tests__/react/xstream/index.tsx
+++ b/base/__tests__/react/xstream/index.tsx
@@ -2,13 +2,14 @@ import * as React from 'react'
 import {
     withEffects,
     Handler,
-    ObservableComponent,
+    CallbackEffect,
     PropEffect
 } from '../../../../packages/refract-xstream/src'
 import {
     aperture,
     toPropsAperture,
     toMergedPropsAperture,
+    toCallbackAperture,
     asPropsAperture,
     Effect,
     Props,
@@ -209,5 +210,57 @@ describe('refract-xstream', () => {
         expect(() => mount(<WithEffects />)).toThrow()
 
         jest.clearAllMocks()
+    })
+
+    describe('toCallback', () => {
+        describe('when the callback prop exists', () => {
+            it('should call the callback', () => {
+                const callback = jest.fn()
+                interface Props {
+                    callback: (message: any) => void
+                }
+                const WithEffects = withEffects<Props, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                mount(<WithEffects callback={callback} />)
+
+                expect(callback).toHaveBeenCalledWith('Hello world!')
+            })
+        })
+
+        describe('when the callback prop does not exist', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                const WithEffects = withEffects<{}, CallbackEffect<string>>(
+                    toCallbackAperture
+                )(() => null)
+
+                mount(<WithEffects />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
+
+        describe('when the prop exists but is not a function', () => {
+            it('should log an error', () => {
+                const spy = jest.fn()
+                jest.spyOn(global.console, 'error').mockImplementation(spy)
+                // @ts-ignore
+                const WithEffects = withEffects<
+                    { callback: string },
+                    CallbackEffect<string>
+                >(toCallbackAperture)(() => null)
+
+                mount(<WithEffects callback="string" />)
+
+                expect(spy).toHaveBeenCalled()
+
+                jest.clearAllMocks()
+            })
+        })
     })
 })

--- a/base/react/configureComponent.ts
+++ b/base/react/configureComponent.ts
@@ -1,5 +1,5 @@
 import { Handler, ErrorHandler, PushEvent } from './baseTypes'
-import { PROPS_EFFECT } from './effects'
+import { CALLBACK_EFFECT, PROPS_EFFECT } from './effects'
 import {
     Listener,
     Subscription,
@@ -79,6 +79,24 @@ const configureComponent = <Props, Effect, Context>(
                         replace: payload.replace,
                         props: payload.props
                     })
+                }
+            } else if (effect && effect.type === CALLBACK_EFFECT) {
+                let error
+                const {
+                    payload: { propName, data }
+                } = effect
+
+                if (!instance.props[propName]) {
+                    error = `prop ${propName} not found in ${componentName} (component).`
+                } else if (typeof instance.props[propName] !== 'function') {
+                    error = `prop ${propName} in ${componentName} (component) is not a function.`
+                }
+
+                if (error) {
+                    // tslint:disable-next-line
+                    console.error(`Refract callback effect failed: ${error}`)
+                } else {
+                    instance.props[propName](data)
                 }
             } else {
                 effectHandler(effect)

--- a/base/react/effects.ts
+++ b/base/react/effects.ts
@@ -1,5 +1,6 @@
 export const PROPS_EFFECT: string = '@@refract/effect/props'
 export const COMPONENT_EFFECT: string = '@@refract/effect/component'
+export const CALLBACK_EFFECT: string = '@@refract/effect/callback'
 
 export interface PropEffect<Props = object> {
     type: string
@@ -12,6 +13,14 @@ export interface PropEffect<Props = object> {
 export interface ComponentEffect<Data = object> {
     type: string
     payload: Data
+}
+
+export interface CallbackEffect<Data = any> {
+    type: string
+    payload: {
+        data?: Data
+        propName: string
+    }
 }
 
 export const toProps = <Props>(props: Props): PropEffect<Props> => ({
@@ -33,4 +42,14 @@ export const asProps = <Props>(props: Props): PropEffect<Props> => ({
 export const toRender = <Data>(data: Data): ComponentEffect<Data> => ({
     type: COMPONENT_EFFECT,
     payload: data
+})
+
+export const toCallback = <Data>(propName: string) => (
+    data?: Data
+): CallbackEffect<Data> => ({
+    type: CALLBACK_EFFECT,
+    payload: {
+        data,
+        propName
+    }
 })

--- a/base/react/index.ts
+++ b/base/react/index.ts
@@ -14,6 +14,9 @@ import {
     PROPS_EFFECT,
     PropEffect,
     toRender,
+    CALLBACK_EFFECT,
+    CallbackEffect,
+    toCallback,
     COMPONENT_EFFECT,
     ComponentEffect
 } from './effects'
@@ -37,6 +40,9 @@ export {
     useRefract,
     ObservableComponentBase,
     toRender,
+    CALLBACK_EFFECT,
+    CallbackEffect,
+    toCallback,
     COMPONENT_EFFECT,
     ComponentEffect
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@
     *   [compose](./api/compose.md)
     *   [withEffects](./api/withEffects.md)
     *   [toProps, asProps](./api/props.md)
+    *   [toCallback](./api/toCallback.md)
     *   [useRefract](./api/useRefract.md)
     *   [refractEnhancer (Redux)](./api/refractEnhancer.md)
 *   [Glossary](./glossary.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,6 +5,7 @@
 *   [compose](compose.md)
 *   [withEffects](withEffects.md)
 *   [toProps, asProps](props.md)
+*   [toCallback](toCallback.md)
 *   [useRefract](useRefract.md)
 
 ### Redux Packages

--- a/docs/api/toCallback.md
+++ b/docs/api/toCallback.md
@@ -1,0 +1,23 @@
+# toCallback
+
+## Packages
+
+`toCallback` is provided by our React, Inferno or Preact packages - `refract-*`, `refract-inferno-*`, `refract-preact-*`.
+
+## Arguments
+
+`toCallback` is a curried function which takes two arguments: the name of the prop you want to call (as a string), and the data you want to pass into this callback.
+
+## Returns
+
+Similar to a Redux action creator, it returns an object containing `type` and `payload` attributes, so it can be recognised by Refract.
+
+```js
+export const toCallback = propName => data => ({
+    type: CALLBACK_EFFECT,
+    payload: {
+        data,
+        propName
+    }
+})
+```

--- a/docs/usage/pushing-to-props.md
+++ b/docs/usage/pushing-to-props.md
@@ -5,10 +5,11 @@ By now, you should have a better understanding of what Refract does:
 *   It allows you to observe data sources ([React](./observing-react.md), [redux](./observing-redux), [anything else](./observing-anything.md))
 *   It allows you to push data to an effect handler (see [handling effects](./handling-effects.md))
 
-Refract has three built-in effect handlers, to:
+Refract has four built-in effect handlers, to:
 
 *   Pass additional props to the child it wraps
 *   Replace props
+*   Call props
 *   Render components
 
 This section focuses on adding and replacing props, and its applications. All React, Preact and Inferno packages export two effect creators: `toProps` and `asProps`. They both take an object of props.
@@ -29,7 +30,7 @@ const DoubleValue = ({ value, doubledValue }) => (
 )
 
 const aperture = (component, { initialCount }) => {
-    component.observe('value').pipe(map(value => toProps({
+    return component.observe('value').pipe(map(value => toProps({
         doubledValue: 2 * value
     })))
 }
@@ -44,6 +45,27 @@ export default withEffects(aperture)(DoubleValue)
 It allows you to fully control what props are passed through, and can result in performance benefits by controlling exactly when a component re-renders.
 
 Essentially, `toProps` and `asProps` allow you to inject data into components, by using existing props or external data sources (sideways data loading).
+
+## Calling Props
+
+`toCallbck` is used to declaratively tell Refract to call your component's props with some data.
+
+In the example below, every time the `value` prop changes, the stream debounces the value for one second, and then calls `props.onCommit` with the new value.
+
+```js
+import React from 'react'
+import { withEffects, toCallback } from 'refract-rxjs'
+import { debounceTime, map } from 'rxjs/operators'
+
+const Input = props => <input {...props} />
+
+const aperture = component =>
+    component
+        .observe('value')
+        .pipe(debounceTime(1000), map(toCallback('onCommit')))
+
+export const DebouncedInput = withEffects(aperture)(Input)
+```
 
 ## Stateful Apertures
 


### PR DESCRIPTION
So far every time I've used Refract I've built this exact functionality into every custom handler - think it makes sense for this to be included in the library!

Similar to `toProps` and `asProps`, it's a helper function which triggers a special case in the combined effect handler. It's called like `toCallback('propName')('data')`; if `props.propName` exists, it calls `props.propName('data')`! 🎉 

This is super useful when building reusable components - for example my go-to example of a debounced input component would look like this:

```js
import { withEffects, toCallback, toProps } from 'refract-rxjs'
import { BehaviorSubject, merge, of } from 'rxjs'
import { debounceTime, map, startWith } from 'rxjs/operators'

import Input from './Input'

const aperture = (component, { timeout = 300, value = '' }) => {
	const value$ = new BehaviorSubject(value)
	const onChange = e => value$.next(e.target.value)

	const onChange$ = value$.pipe(
		map(toCallback('onChange'))
	)
	const onCommit$ = value$.pipe(
		debounceTime(timeout),
		map(toCallback('onCommit')),
	)
	const render$ = value$.pipe(
		map(value => toProps({ value })),
	)

	return merge(
		of(toProps({ onChange })),
		render$,
		onChange$,
		onCommit$,
	)
}

export default withEffects(aperture)(Input)
```