### PR TITLE
RxJS routing example fails with error "Cannot read property activeTab of null"

### DIFF
--- a/examples/routing/rxjs/src/StateContainer.js
+++ b/examples/routing/rxjs/src/StateContainer.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 const StateContainer = props => {
-    const [activeTab, setActiveTab] = useState(null)
+    const [activeTab, setActiveTab] = useState("ObiWan")
 
     return props.children({
         activeTab,

--- a/examples/routing/rxjs/src/index.js
+++ b/examples/routing/rxjs/src/index.js
@@ -41,8 +41,8 @@ const handler = ({ setActiveTab }) => effect => {
     switch (effect.type) {
         case 'NAVIGATION':
             const path = document.location.pathname
-            const search = effect.state.activeTab
-                ? `?tab=${effect.state.activeTab}`
+            const search = effect.state
+                ? `?tab=${effect.state}`
                 : ''
             const methodName = effect.replace ? 'replaceState' : 'pushState'
             window.history[methodName](effect.state, null, `${path}${search}`)


### PR DESCRIPTION
This PR makes minor edits to get the routing example for RxJS to not fail with an error on load of the root URL (an issue described in #164). 

To fix this issue, a default tab is added and minor edits are made to the construction of the path name.