### PR TITLE
use new Observable over writing own version

### DIFF
--- a/base/react/observable.ts
+++ b/base/react/observable.ts
@@ -110,13 +110,7 @@ const getComponentBase = (
     }
 }
 
-export const createObservable = subscribe => ({
-    subscribe,
-    // @ts-ignore
-    [(typeof Symbol === 'function' && Symbol.observable) || '@@observable']() {
-        return this
-    }
-})
+export const createObservable = subscribe => new Observable(subscribe)
 
 export const getObserve = <Props>(getProp, data, decoratedProps) => {
     return function observe<Type>(propName?, valueTransformer?) {


### PR DESCRIPTION
In react-native, the custom observable function is breaking on components wrapped with withEffects()

This will be released on top of the 5-RC as a patch